### PR TITLE
🚸 improve cpp-linter configuration

### DIFF
--- a/.github/workflows/reusable-cpp-linter.yml
+++ b/.github/workflows/reusable-cpp-linter.yml
@@ -75,7 +75,7 @@ jobs:
           tidy-checks: ""
           version: ${{ env.clang-version }}
           ignore: "build|include/python|src/python"
-          thread-comments: ${{ github.event_name == 'pull_request' }}
+          thread-comments: ${{ github.event_name == 'pull_request' && 'update' }}
           step-summary: true
           database: "build"
           extra-args: -std=c++17

--- a/.github/workflows/reusable-cpp-linter.yml
+++ b/.github/workflows/reusable-cpp-linter.yml
@@ -6,6 +6,10 @@ on:
         description: "Clang version to use"
         default: 18
         type: number
+      files-changed-only:
+        description: "Whether to only lint files that have changed"
+        default: true
+        type: boolean
       cmake-args:
         description: "Additional arguments to pass to CMake"
         default: ""
@@ -75,7 +79,7 @@ jobs:
           step-summary: true
           database: "build"
           extra-args: -std=c++17
-          files-changed-only: true
+          files-changed-only: ${{ inputs.files-changed-only }}
       - name: Fail if linter found errors
         if: steps.linter.outputs.checks-failed > 0
         run: echo "Linter found errors" && exit 1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -64,12 +64,3 @@ repos:
     hooks:
       - id: check-dependabot
       - id: check-github-workflows
-      - id: check-jsonschema
-        name: "Validate Release Drafter configuration"
-        files: ^\.github/release-drafter.yml$
-        types: [yaml]
-        args:
-          [
-            "--schemafile",
-            "https://raw.githubusercontent.com/release-drafter/release-drafter/master/schema.json",
-          ]


### PR DESCRIPTION
This PR adds the option to request a full clang-tidy run via a workflow option. This can be useful after updates of the clang-tidy version so that the whole code base can be checked once in a PR and it happens less frequently that warnings then pop up in subsequent PRs.

It also enables the `update` feature for the cpp-linter thread comment which repeatedly updates the linter comment instead of always creating a new one. This should lower the notification noise.