### PR TITLE
🚸 improve coverage data collection

### DIFF
--- a/.github/workflows/reusable-cpp-ci.yml
+++ b/.github/workflows/reusable-cpp-ci.yml
@@ -1,10 +1,6 @@
 name: 🇨‌ • CI
 on:
   workflow_call:
-    secrets:
-      token:
-        description: "The token to use for Codecov"
-        required: true
     inputs:
       cmake-args:
         description: "Additional arguments to pass to CMake on every OS"
@@ -69,8 +65,6 @@ jobs:
   coverage:
     name: 📈
     uses: ./.github/workflows/reusable-cpp-coverage.yml
-    secrets:
-      token: ${{ secrets.token }}
     with:
       cmake-args: ${{ inputs.cmake-args }} ${{ inputs.cmake-args-ubuntu }}
       setup-z3: ${{ inputs.setup-z3 }}

--- a/.github/workflows/reusable-cpp-coverage.yml
+++ b/.github/workflows/reusable-cpp-coverage.yml
@@ -1,10 +1,6 @@
 name: 🇨 • Coverage
 on:
   workflow_call:
-    secrets:
-      token:
-        description: "The token to use for Codecov"
-        required: true
     inputs:
       cmake-args:
         description: "Additional arguments to pass to CMake"
@@ -23,6 +19,8 @@ jobs:
   coverage:
     name: 📈 Coverage
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     env:
       CMAKE_BUILD_PARALLEL_LEVEL: 4
       CTEST_PARALLEL_LEVEL: 4
@@ -59,4 +57,4 @@ jobs:
         with:
           fail_ci_if_error: true
           flags: cpp
-          token: ${{ secrets.token }}
+          use_oidc: true

--- a/.github/workflows/reusable-python-ci.yml
+++ b/.github/workflows/reusable-python-ci.yml
@@ -108,6 +108,8 @@ jobs:
     permissions:
       id-token: write
     steps:
+      # check out the repository (mostly for the codecov config)
+      - uses: actions/checkout@v4
       # download coverage reports from all jobs
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/reusable-python-ci.yml
+++ b/.github/workflows/reusable-python-ci.yml
@@ -2,10 +2,6 @@ name: 🐍 • CI
 
 on:
   workflow_call:
-    secrets:
-      token:
-        description: "The token to use for Codecov"
-        required: true
     inputs:
       setup-z3:
         description: "Whether to set up Z3"
@@ -123,4 +119,4 @@ jobs:
         with:
           fail_ci_if_error: true
           flags: python
-          token: ${{ secrets.token }}
+          use_oidc: true

--- a/.github/workflows/reusable-python-ci.yml
+++ b/.github/workflows/reusable-python-ci.yml
@@ -69,8 +69,6 @@ jobs:
       python-version: ${{ matrix.python-version }}
       setup-z3: ${{ inputs.setup-z3 }}
       z3-version: ${{ inputs.z3-version }}
-    secrets:
-      token: ${{ secrets.token }}
 
   python-tests-macos:
     name: 🍎 ${{ matrix.python-version }} ${{ matrix.runs-on }}
@@ -89,8 +87,6 @@ jobs:
       python-version: ${{ matrix.python-version }}
       setup-z3: ${{ inputs.setup-z3 }}
       z3-version: ${{ inputs.z3-version }}
-    secrets:
-      token: ${{ secrets.token }}
 
   python-tests-windows:
     name: 🏁 ${{ matrix.python-version }}
@@ -108,5 +104,23 @@ jobs:
       python-version: ${{ matrix.python-version }}
       setup-z3: ${{ inputs.setup-z3 }}
       z3-version: ${{ inputs.z3-version }}
-    secrets:
-      token: ${{ secrets.token }}
+
+  python-coverage-upload:
+    name: 📈
+    needs: [python-tests-ubuntu, python-tests-macos, python-tests-windows]
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      # download coverage reports from all jobs
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: coverage-*
+          path: coverage-reports
+          merge-multiple: true
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          fail_ci_if_error: true
+          flags: python
+          token: ${{ secrets.token }}

--- a/.github/workflows/reusable-python-tests.yml
+++ b/.github/workflows/reusable-python-tests.yml
@@ -1,10 +1,6 @@
 name: 🐍 • Tests
 on:
   workflow_call:
-    secrets:
-      token:
-        description: "The token to use for Codecov"
-        required: true
     inputs:
       runs-on:
         description: "The platform to run the tests on (ubuntu-latest, macos-latest, windows-latest)"
@@ -62,14 +58,13 @@ jobs:
           python-versions: ${{ inputs.python-version }}
       # run the nox minimums session (assumes a nox session named "minimums" exists) with coverage
       - name: Test on 🐍 ${{ inputs.python-version }} with minimal versions
-        run: nox -s minimums-${{ inputs.python-version }} --verbose -- --cov --cov-report=xml
+        run: nox -s minimums-${{ inputs.python-version }} --verbose -- --cov --cov-report=xml:coverage-${{ inputs.python-version }}-${{ inputs.runs-on }}.xml
       # run the nox tests session (assumes a nox session named "tests" exists) with coverage
       - name: Test on 🐍 ${{ inputs.python-version }}
-        run: nox -s tests-${{ inputs.python-version }} --verbose -- --cov --cov-report=xml --cov-append
-      # upload coverage to Codecov
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        run: nox -s tests-${{ inputs.python-version }} --verbose -- --cov --cov-report=xml:coverage-${{ inputs.python-version }}-${{ inputs.runs-on }}.xml --cov-append
+      # upload the report as an artifact to GitHub so that it can later be uploaded to Codecov
+      - name: Upload coverage report for 🐍 ${{ inputs.python-version }} on ${{ inputs.runs-on }}
+        uses: actions/upload-artifact@v4
         with:
-          fail_ci_if_error: true
-          flags: python
-          token: ${{ secrets.token }}
+          name: coverage-${{ inputs.python-version }}-${{ inputs.runs-on }}
+          path: coverage-*


### PR DESCRIPTION
This PR improves how coverage data is collected and uploaded to codecov. Since we upload quite a couple of reports, the codecov CI was frequently failing, especially on PRs from forks.

This PR changes the workflows so that they first upload all Python coverage reports as artifacts, which are then collected and uploaded in one go.

Furthermore, this PR switches to using OIDC instead of `CODECOV_TOKEN` which eliminates the need for storing the codecov token as a repository secret.

An added benefit of this approach is that there is only one Python coverage upload; independent from the number of jobs and Python versions. Thus, the same coverage configuration can be used in all projects.

Before merging, this PR needs testing in at least one of the upstream repositories.