### PR TITLE
✨ add reusable mqt-core update workflow

### DIFF
--- a/.github/workflows/reusable-mqt-core-update.yml
+++ b/.github/workflows/reusable-mqt-core-update.yml
@@ -1,0 +1,99 @@
+name: ⬆️ Update MQT Core
+on:
+  workflow_call:
+
+jobs:
+  update-mqt-core:
+    name: ⬆️ Update MQT Core
+    runs-on: ubuntu-latest
+    steps:
+      # Check out the repository
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      # Parse the MQT Core version and the revision from the `cmake/ExternalDependencies.cmake` file.
+      # The relevant portions of the file have the format:
+      # ```cmake
+      #   set(MQT_CORE_VERSION <major>.<minor>.<patch>\n
+      #   # ...
+      #   set(MQT_CORE_REV "<tag, branch or commit hash>"\n
+      # ```
+      # where `<major>.<minor>.<patch>` is the version and `<tag, branch or commit hash>` is the revision.
+      - name: Parse MQT Core version and revision
+        id: get-used-version
+        run: |
+          echo "Checking if cmake/ExternalDependencies.cmake exists..."
+          ls -l cmake/ExternalDependencies.cmake || true
+          echo "Attempting to parse version and revision..."
+          version=$(sed -nE 's/set\(MQT_CORE_VERSION\s+([0-9]+\.[0-9]+\.[0-9]+)/\1/p' cmake/ExternalDependencies.cmake)
+          echo "Parsed version: $version"
+          revision=$(sed -nE 's/set\(MQT_CORE_REV\s+"([^"]+)"/\1/p' cmake/ExternalDependencies.cmake)
+          echo "Parsed revision: $revision"
+          echo "version=$version" >> $GITHUB_OUTPUT
+          echo "revision=$revision" >> $GITHUB_OUTPUT
+      # Query the latest tag of mqt-core and its commit SHA via the GitHub API
+      # Use {github.token} to authenticate with the GitHub API.
+      - name: Get latest release of MQT Core
+        id: get-latest-release
+        run: |
+          echo "Querying the latest release of MQT Core..."
+          latest_release=$(curl -s -H "Authorization: token ${{ github.token }}" https://api.github.com/repos/cda-tum/mqt-core/releases/latest)
+          tag=$(echo $latest_release | jq -r '.tag_name')
+          latest_version=${tag#v}
+          echo "latest_release=$latest_release"
+          echo "tag=$tag"
+          echo "latest_version=$latest_version"
+          echo "latest_version=$latest_version" >> $GITHUB_OUTPUT
+          echo "Querying the tags of MQT Core..."
+          tags=$(curl -s -H "Authorization: token ${{ github.token }}" https://api.github.com/repos/cda-tum/mqt-core/tags)
+          echo "tags=$tags"
+          latest_commit=$(echo $tags | jq -r '.[0].commit.sha')
+          echo "latest_commit=$latest_commit"
+          echo "latest_commit=$latest_commit" >> $GITHUB_OUTPUT
+      # Install the `semver` tool for making semantic version comparisons.
+      - name: Install semver
+        run: |
+          wget -O /usr/local/bin/semver \
+          https://raw.githubusercontent.com/fsaintjacques/semver-tool/master/src/semver
+          chmod +x /usr/local/bin/semver
+      # Compare the used version with the latest version based on SemVer.
+      # If the latest version is newer or the version is the same, but the revision
+      # is different, set the output to update MQT Core.
+      - name: Compare versions
+        id: compare-versions
+        run: |
+          if semver compare ${{ steps.get-used-version.outputs.version }} ${{ steps.get-latest-release.outputs.latest_version }} < 0; then
+            update=true
+          elif [ ${{ steps.get-used-version.outputs.version }} = ${{ steps.get-latest-release.outputs.latest_version }} ] && [ ${{ steps.get-used-version.outputs.revision }} != ${{ steps.get-latest-release.outputs.latest_commit }} ]; then
+            update=true
+          else
+            update=false
+          fi
+          echo "update=$update"
+          echo "update=$update" >> $GITHUB_OUTPUT
+      # Update the MQT Core version and revision in the `cmake/ExternalDependencies.cmake` file.
+      - name: Update MQT Core version and revision
+        id: update-version
+        if: steps.compare-versions.outputs.update == 'true'
+        run: |
+          sed -i 's/set(MQT_CORE_VERSION.*/set(MQT_CORE_VERSION ${{ steps.get-latest-release.outputs.latest_version }}/' cmake/ExternalDependencies.cmake
+          sed -i 's/set(MQT_CORE_REV.*/set(MQT_CORE_REV "${{ steps.get-latest-release.outputs.latest_commit }}"/' cmake/ExternalDependencies.cmake
+          git diff
+      # Create a pull request to merge the changes into the main branch.
+      - name: Create pull request
+        id: create-pull-request
+        if: steps.compare-versions.outputs.update == 'true'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ github.token }}
+          commit-message: "⬆️ Update `cda-tum/mqt-core`"
+          title: "⬆️ Update `cda-tum/mqt-core`"
+          body: |
+            This pull request updates [MQT Core](https://github.com/cda-tum/mqt-core)
+            - from cda-tum/mqt-core@${{ steps.get-used-version.outputs.revision }} (version v${{ steps.get-used-version.outputs.version }})
+            - to cda-tum/mqt-core@${{ steps.get-latest-release.outputs.latest_commit }} (version v${{ steps.get-latest-release.outputs.latest_version }}).
+
+            **Full Changelog**: https://github.com/cda-tum/mqt-core/compare/${{ steps.get-used-version.outputs.revision }}...${{ steps.get-latest-release.outputs.latest_commit }}
+          branch: "update-mqt-core-${{ steps.get-latest-release.outputs.latest_commit }}"
+          labels: "dependencies,c++"
+          base: "main"


### PR DESCRIPTION
This PR adds a reusable workflow for automatically updating a FetchContent-managed mqt-core dependency.

The workflow assumes
- that there is a `cmake/ExternalDependencies.cmake` file
- that file contains (an adaptation of) the following lines
  ```cmake
  # cmake-format: off
  set(MQT_CORE_VERSION 2.5.1
      CACHE STRING "MQT Core version")
  set(MQT_CORE_REV "0e4ff9e0521886449027b252c65913e1afa863b0"
      CACHE STRING "MQT Core identifier (tag, branch or commit hash)")
  # cmake-format: on
  ```
  Note that the `# cmake-format: off` and `# cmake-format: on` are required to have the version and tag appear on the same line.

It will check the latest release version (and the corresponding commit SHA) from GitHub and do a SemVer comparison with the version extracted from the CMake file.
If the version is newer or it's the same but the SHA is different, it will update the CMake file and submit a pull request.