### PR TITLE
💥 require token for creating pull requests in auto update

### DIFF
--- a/.github/workflows/reusable-mqt-core-update.yml
+++ b/.github/workflows/reusable-mqt-core-update.yml
@@ -1,6 +1,16 @@
 name: ⬆️ Update MQT Core
 on:
   workflow_call:
+    secrets:
+      token:
+        description: |
+          Personal Access Token (PAT) with `repo` scope.
+          You can pass the `github.token` provided by GitHub Actions,
+          which does not have these permissions and, hence, cannot
+          trigger workflows in the PRs created by this workflow.
+          As a workaround, such a PR can be closed and re-opened
+          by a maintainer to trigger the PR workflows.
+        required: true
 
 jobs:
   update-mqt-core:
@@ -85,7 +95,7 @@ jobs:
         if: steps.compare-versions.outputs.update == 'true'
         uses: peter-evans/create-pull-request@v6
         with:
-          token: ${{ github.token }}
+          token: ${{ secrets.token }}
           commit-message: "⬆️ Update `cda-tum/mqt-core`"
           title: "⬆️ Update `cda-tum/mqt-core`"
           body: |


### PR DESCRIPTION
This PR adapts the reusable auto-update workflow for mqt-core to require a token for creating the update PR.

Ideally, this token is a Personal Access Token with `repo` scope because this allows the creation of the PR to also trigger corresponding `on: pull request` workflows in the PR.

Alternatively, the regular `{{ github.token }}` can be used, which still allows to create PRs, but workflows will not be run automatically for the created PR.
In order to still run workflows for such PRs, the PR can be manually closed and re-opened, which explicitly triggers the workflow runs.