### PR TITLE
✨ allow skipping testing on latest Python

### DIFF
--- a/.github/workflows/reusable-python-ci.yml
+++ b/.github/workflows/reusable-python-ci.yml
@@ -49,7 +49,7 @@ jobs:
         id: baipp
       # reduce the list of Python versions by one if the latest Python version is to be skipped
       - name: 🐍 Conditionally reduce the list of considered Python versions
-        run: echo "supported-python-versions=$(echo '${{ steps.baipp.outputs.supported_python_classifiers_json_array }}' | jq --raw-output 'if ${{ inputs.skip-testing-latest-python }} then .[:-1] else . end')" >> $GITHUB_OUTPUT
+        run: echo "supported-python-versions=$(echo '${{ steps.baipp.outputs.supported_python_classifiers_json_array }}' | jq -rc 'if ${{ inputs.skip-testing-latest-python }} then .[:-1] else . end')" >> $GITHUB_OUTPUT
         id: supported-python-versions
       # determine the maximum supported Python version
       - name: 🐍 Determine maximum supported Python version

--- a/.github/workflows/reusable-python-ci.yml
+++ b/.github/workflows/reusable-python-ci.yml
@@ -3,6 +3,10 @@ name: 🐍 • CI
 on:
   workflow_call:
     inputs:
+      skip-testing-latest-python:
+        description: "Whether to skip testing on the latest Python version"
+        default: false
+        type: boolean
       setup-z3:
         description: "Whether to set up Z3"
         default: false
@@ -43,12 +47,16 @@ jobs:
       # run the build-and-inspect-python-package action (outputs supported Python versions)
       - uses: hynek/build-and-inspect-python-package@v2
         id: baipp
+      # reduce the list of Python versions by one if the latest Python version is to be skipped
+      - name: 🐍 Conditionally reduce the list of considered Python versions
+        run: echo "supported-python-versions=$(echo '${{ steps.baipp.outputs.supported_python_classifiers_json_array }}' | jq --raw-output 'if ${{ inputs.skip-testing-latest-python }} then .[:-1] else . end')" >> $GITHUB_OUTPUT
+        id: supported-python-versions
       # determine the maximum supported Python version
       - name: 🐍 Determine maximum supported Python version
-        run: echo "max-python-version=$(echo '${{ steps.baipp.outputs.supported_python_classifiers_json_array }}' | jq --raw-output '.[-1]')" >> $GITHUB_OUTPUT
+        run: echo "max-python-version=$(echo '${{ steps.supported-python-versions.outputs.supported-python-versions }}' | jq --raw-output '.[-1]')" >> $GITHUB_OUTPUT
         id: max-python-version
     outputs:
-      python-versions: ${{ steps.baipp.outputs.supported_python_classifiers_json_array }}
+      python-versions: ${{ steps.supported-python-versions.outputs.supported-python-versions }}
       max-python-version: ${{ steps.max-python-version.outputs.max-python-version }}
 
   python-tests-ubuntu:


### PR DESCRIPTION
This PR allows skipping the testing pipeline on the latest supported Python version.
Under Linux, this will simply not test under that version, but all other supported versions.
Under macOS and Windows, it will test on the minimal supported version and the second latest version supported.

This is especially helpful when new Python versions are released and the ecosystem takes some time to settle and provide wheels for the new version.

The intention would be to enable the `skip-testing-latest-python` flag once a new Python version is released to get our own wheel builds out as soon as possible.
Ideally immediately after that, a follow-up PR (along with a tracking issue) can be created that disables the flag again and that helps to keep track of the progress towards fully supporting new Python versions.