### PR TITLE
🩹 fix path to `semver` in MQT Core update workflow

### DIFF
--- a/.github/workflows/reusable-mqt-core-update.yml
+++ b/.github/workflows/reusable-mqt-core-update.yml
@@ -88,7 +88,7 @@ jobs:
               update=false
             fi
           else
-            if semver compare ${{ steps.get-used-version.outputs.version }} ${{ steps.get-latest-release.outputs.latest_version }} < 0; then
+            if /usr/local/bin/semver compare ${{ steps.get-used-version.outputs.version }} ${{ steps.get-latest-release.outputs.latest_version }} < 0; then
               update=true
             elif [ ${{ steps.get-used-version.outputs.version }} = ${{ steps.get-latest-release.outputs.latest_version }} ] && [ ${{ steps.get-used-version.outputs.revision }} != ${{ steps.get-latest-tag-sha.outputs.latest_tag_sha }} ]; then
               update=true


### PR DESCRIPTION
This small PR fixes an issue where the `semver` command couldn't be found when running the MQT Core update action.
I suppose this is due to `/usr/local/bin` not being on the `PATH` on GitHub action runners.