### PR TITLE
♻️ combine builds for emulated wheels

### DIFF
--- a/.github/workflows/reusable-python-packaging.yml
+++ b/.github/workflows/reusable-python-packaging.yml
@@ -117,50 +117,16 @@ jobs:
           name: cibw-wheels-${{ matrix.runs-on }}-${{ strategy.job-index }}
           path: wheelhouse/*.whl
 
-  dist:
-    if: ${{ !inputs.pure-python }}
-    name: 📦 Check
-    runs-on: ubuntu-latest
-    steps:
-      # check out the repository (including submodules and all history)
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
-          fetch-depth: 0
-      # optionally set up Z3
-      - if: ${{ inputs.setup-z3 }}
-        name: Setup Z3
-        uses: cda-tum/setup-z3@v1
-        with:
-          version: ${{ inputs.z3-version }}
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-      # set up mold as linker for faster C++ builds (Linux only)
-      - name: Set up mold as linker (Linux only)
-        uses: rui314/setup-mold@v1
-      # run the build-and-inspect-python-package action (outputs supported Python versions)
-      - uses: hynek/build-and-inspect-python-package@v2
-        id: baipp
-        with:
-          skip-wheel: "true"
-      # create identifiers for supported Python versions
-      - name: 🐍 create identifiers for supported Python versions
-        id: python-versions
-        run: echo "python-versions=$(echo '${{ steps.baipp.outputs.supported_python_classifiers_json_array }}' | jq -c --raw-output 'map("cp" + . | gsub("\\."; ""))')" >> $GITHUB_OUTPUT
-    outputs:
-      python-versions: ${{ steps.python-versions.outputs.python-versions }}
-
   build_wheels_emulation:
     if: ${{ !inputs.pure-python }}
     needs: dist
-    name: 🎡 ${{ matrix.arch }} ${{ matrix.python }}
+    name: 🎡 ${{ matrix.arch }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         # build wheels for all supported Python versions on all platforms that require emulation
         arch: ["s390x", "ppc64le", "aarch64"]
-        python: ${{ fromJson(needs.dist.outputs.python-versions) }}
     steps:
       # check out the repository (including submodules and all history)
       - uses: actions/checkout@v4
@@ -180,10 +146,9 @@ jobs:
         uses: pypa/cibuildwheel@v2.20
         env:
           CIBW_ARCHS_LINUX: ${{ matrix.arch }}
-          CIBW_BUILD: ${{ matrix.python }}*
           CIBW_TEST_SKIP: "cp*"
       # upload the wheels as an artifact
       - uses: actions/upload-artifact@v4
         with:
-          name: cibw-wheels-${{ matrix.arch }}-${{ matrix.python }}-${{ strategy.job-index }}
+          name: cibw-wheels-${{ matrix.arch }}-${{ strategy.job-index }}
           path: ./wheelhouse/*.whl


### PR DESCRIPTION
Instead of `3 * |supported python versions|` jobs, this will only create `3` jobs to build wheels on platforms that need emulation. Tools running this workflow and are using scikit-build-core as a build backend, should set

```toml
[tool.scikit-build]
# ...
build-dir = "build/{build_type}"
# ...
```

so that the build directory can be reused across builds. This only requires the actual binding target to be recompiled.
There is a very slim chance that this needs to be reverted or refactored if it turns out that the MQT QMAP builds exceed the six hour GitHub limit.

Tools should also set
```toml
[tool.cibuildwheel.windows]
# ...
environment = { SKBUILD_CMAKE_ARGS="--fresh" }
# ...
```

to avoid problems with old link settings remaining in the CMake cache on Windows.