### PR TITLE
✨ moving minor tags for workflows

### DIFF
--- a/.github/workflows/update-major-minor-tag.yml
+++ b/.github/workflows/update-major-minor-tag.yml
@@ -1,0 +1,28 @@
+name: Update the vX.Y tag
+
+on:
+  release:
+    types: [released]
+  workflow_dispatch:
+    inputs:
+      TAG_NAME:
+        description: "Tag name that the major.minor tag will point to"
+        required: true
+
+env:
+  TAG_NAME: ${{ github.event.inputs.TAG_NAME || github.event.release.tag_name }}
+
+jobs:
+  update_tag:
+    name: Update the major.minor tag to include the ${{ github.event.inputs.TAG_NAME || github.event.release.tag_name }} changes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Update the ${{ env.TAG_NAME }} tag
+        id: update-major-minor-tag
+        uses: joerick/update-vX.Y-tag-action@v1.0
+        with:
+          source-tag: ${{ env.TAG_NAME }}


### PR DESCRIPTION
This PR introduces a workflow for maintaining moving minor version tags.
This should reduce the frequency in which consumers of these workflows have to update.
On the other hand, it also mandates that patch releases do not break consumers.

Adapted from https://github.com/pypa/cibuildwheel/blob/main/.github/workflows/update-major-minor-tag.yml

Fixes #14 