### PR TITLE
🩹 fix emulation wheel build precondition

### DIFF
--- a/.github/workflows/reusable-python-packaging.yml
+++ b/.github/workflows/reusable-python-packaging.yml
@@ -119,7 +119,6 @@ jobs:
 
   build_wheels_emulation:
     if: ${{ !inputs.pure-python }}
-    needs: dist
     name: 🎡 ${{ matrix.arch }}
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
A quick follow up to #22 that fixes an oversight in the workflow configuration.