### PR TITLE
fix: :bug: Fix incorrect usage of semver tool

### DIFF
--- a/.github/workflows/reusable-mqt-core-update.yml
+++ b/.github/workflows/reusable-mqt-core-update.yml
@@ -109,7 +109,7 @@ jobs:
         run: |
           if [ ${{ inputs.update-to-head }} = true ]; then
             if [ ${{ steps.get-latest-commit.outputs.latest_commit_sha }} != ${{ steps.get-latest-tag-sha.outputs.latest_tag_sha }} ]; then
-              new_version=$(semver -i patch ${{ steps.get-used-version.outputs.version }})
+              new_version=$(semver bump patch ${{ steps.get-used-version.outputs.version }})
             else
               new_version=${{ steps.get-latest-release.outputs.latest_version }}
             fi


### PR DESCRIPTION
The semver tool that is downloaded by this workflow does not provide the option `-i`.

Instead, the equivalent command is `semver bump patch <version>`

Before this pull request, updating the version using this workflow will fail, as `-i` is not recognised. This pull request should fix the issue.