### PR TITLE
♻️ unify Python testing

### DIFF
--- a/.github/workflows/reusable-python-ci.yml
+++ b/.github/workflows/reusable-python-ci.yml
@@ -3,10 +3,6 @@ name: 🐍 • CI
 on:
   workflow_call:
     inputs:
-      skip-testing-latest-python:
-        description: "Whether to skip testing on the latest Python version"
-        default: false
-        type: boolean
       setup-z3:
         description: "Whether to set up Z3"
         default: false
@@ -42,74 +38,23 @@ jobs:
       # set up mold as linker for faster C++ builds
       - name: Set up mold as linker
         uses: rui314/setup-mold@v1
-      # run the build-and-inspect-python-package action (outputs supported Python versions)
       - uses: hynek/build-and-inspect-python-package@v2
-        id: baipp
-      # reduce the list of Python versions by one if the latest Python version is to be skipped
-      - name: 🐍 Conditionally reduce the list of considered Python versions
-        run: echo "supported-python-versions=$(echo '${{ steps.baipp.outputs.supported_python_classifiers_json_array }}' | jq -rc 'if ${{ inputs.skip-testing-latest-python }} then .[:-1] else . end')" >> $GITHUB_OUTPUT
-        id: supported-python-versions
-      # determine the maximum supported Python version
-      - name: 🐍 Determine maximum supported Python version
-        run: echo "max-python-version=$(echo '${{ steps.supported-python-versions.outputs.supported-python-versions }}' | jq --raw-output '.[-1]')" >> $GITHUB_OUTPUT
-        id: max-python-version
-    outputs:
-      python-versions: ${{ steps.supported-python-versions.outputs.supported-python-versions }}
-      max-python-version: ${{ steps.max-python-version.outputs.max-python-version }}
 
-  python-tests-ubuntu:
-    name: 🐧 ${{ matrix.python-version }}
-    needs: dist
+  python-tests:
+    name: 🐍 ${{ matrix.runs-on }}
     strategy:
       fail-fast: false
       matrix:
-        # runs Python testing for all supported Python versions on Ubuntu
-        python-version: ${{ fromJson(needs.dist.outputs.python-versions) }}
-    uses: ./.github/workflows/reusable-python-tests.yml
-    with:
-      runs-on: ubuntu-latest
-      python-version: ${{ matrix.python-version }}
-      setup-z3: ${{ inputs.setup-z3 }}
-      z3-version: ${{ inputs.z3-version }}
-
-  python-tests-macos:
-    name: 🍎 ${{ matrix.python-version }} ${{ matrix.runs-on }}
-    needs: [dist]
-    strategy:
-      fail-fast: false
-      matrix:
-        # runs Python testing for the minimum and maximum supported Python versions on macOS
-        python-version:
-          - ${{ fromJson(needs.dist.outputs.python-versions)[0] }}
-          - ${{ needs.dist.outputs.max-python-version }}
-        runs-on: [macos-13, macos-14]
+        runs-on: [ubuntu-latest, macos-13, macos-14, windows-latest]
     uses: ./.github/workflows/reusable-python-tests.yml
     with:
       runs-on: ${{ matrix.runs-on }}
-      python-version: ${{ matrix.python-version }}
-      setup-z3: ${{ inputs.setup-z3 }}
-      z3-version: ${{ inputs.z3-version }}
-
-  python-tests-windows:
-    name: 🏁 ${{ matrix.python-version }}
-    needs: [dist]
-    strategy:
-      fail-fast: false
-      matrix:
-        # runs Python testing for the minimum and maximum supported Python versions on Windows
-        python-version:
-          - ${{ fromJson(needs.dist.outputs.python-versions)[0] }}
-          - ${{ needs.dist.outputs.max-python-version }}
-    uses: ./.github/workflows/reusable-python-tests.yml
-    with:
-      runs-on: windows-latest
-      python-version: ${{ matrix.python-version }}
       setup-z3: ${{ inputs.setup-z3 }}
       z3-version: ${{ inputs.z3-version }}
 
   python-coverage-upload:
     name: 📈
-    needs: [python-tests-ubuntu, python-tests-macos, python-tests-windows]
+    needs: [python-tests]
     runs-on: ubuntu-latest
     permissions:
       id-token: write

--- a/.github/workflows/reusable-python-tests.yml
+++ b/.github/workflows/reusable-python-tests.yml
@@ -3,11 +3,7 @@ on:
   workflow_call:
     inputs:
       runs-on:
-        description: "The platform to run the tests on (ubuntu-latest, macos-latest, windows-latest)"
-        required: true
-        type: string
-      python-version:
-        description: "The Python version to use"
+        description: "The platform to run the tests on"
         required: true
         type: string
       setup-z3:
@@ -21,7 +17,7 @@ on:
 
 jobs:
   python-tests:
-    name: 🐍 ${{ inputs.python-version }} ${{ inputs.runs-on }}
+    name: 🐍 ${{ inputs.runs-on }}
     runs-on: ${{ inputs.runs-on }}
     env:
       FORCE_COLOR: 3
@@ -46,7 +42,7 @@ jobs:
         with:
           prepend_symlinks_to_path: false
           windows_compile_environment: msvc
-          override_cache_key: python-tests-${{ inputs.runs-on }}-${{ inputs.python-version }}
+          override_cache_key: python-tests-${{ inputs.runs-on }}
       # set up mold as linker for faster C++ builds (Linux only)
       - name: Set up mold as linker (Linux only)
         uses: rui314/setup-mold@v1
@@ -58,17 +54,15 @@ jobs:
           enable-cache: true
       # set up nox for convenient testing
       - uses: wntrblm/nox@2024.04.15
-        with:
-          python-versions: ${{ inputs.python-version }}
       # run the nox minimums session (assumes a nox session named "minimums" exists) with coverage
-      - name: Test on 🐍 ${{ inputs.python-version }} with minimal versions
-        run: nox -s minimums-${{ inputs.python-version }} --verbose -- --cov --cov-report=xml:coverage-${{ inputs.python-version }}-${{ inputs.runs-on }}.xml
+      - name: 🐍 Test with minimal versions
+        run: nox -s minimums --verbose -- --cov --cov-report=xml:coverage-${{ inputs.runs-on }}.xml --cov-append
       # run the nox tests session (assumes a nox session named "tests" exists) with coverage
-      - name: Test on 🐍 ${{ inputs.python-version }}
-        run: nox -s tests-${{ inputs.python-version }} --verbose -- --cov --cov-report=xml:coverage-${{ inputs.python-version }}-${{ inputs.runs-on }}.xml --cov-append
+      - name: 🐍 Test
+        run: nox -s tests --verbose -- --cov --cov-report=xml:coverage-${{ inputs.runs-on }}.xml --cov-append
       # upload the report as an artifact to GitHub so that it can later be uploaded to Codecov
-      - name: Upload coverage report for 🐍 ${{ inputs.python-version }} on ${{ inputs.runs-on }}
+      - name: Upload 🐍 coverage report for ${{ inputs.runs-on }}
         uses: actions/upload-artifact@v4
         with:
-          name: coverage-${{ inputs.python-version }}-${{ inputs.runs-on }}
+          name: coverage-${{ inputs.runs-on }}
           path: coverage-*


### PR DESCRIPTION
This PR refactors the way tests on Python are distributed and run. Instead of running separate sessions for each Python version, this PR changes the workflows to run all sessions in a single workflow run per operating system.
This should allow for maximum caching reuse across builds and reduce the number of CI runners that need to be waited for.
It also reduces the number of macOS runners requested per CI run, which is now fixed to 2 for the python tests regardless of the number of supported Python versions.

While, previously, only the `ubuntu-latest` runner would run tests on all Python versions, this PR changes the workflows so that also macOS and Windows runners test all the versions.
This should not cause a noticable runtime increase given the excessive caching opportunities, both via `ccache` and `uv`.

> [!IMPORTANT]  
> This change will require consuming workflows to adapt their configuration! 
> 
> The `skip-testing-latest-python` workflow input has been removed and the Python versions being tested are solely defined by the nox sessions configuration. 
> Consequently, if a package should not be tested under Python 3.13 yet for example, `"3.13"` should be removed from the `PYTHON_ALL_VERSIONS` array in the `noxfile.py`.