### PR TITLE
🔧 allow to disable emulated wheel build

### DIFF
--- a/.github/workflows/reusable-python-packaging.yml
+++ b/.github/workflows/reusable-python-packaging.yml
@@ -15,6 +15,10 @@ on:
         description: "The version of Z3 to set up"
         default: "4.13.0"
         type: string
+      build-emulated-wheels:
+        description: "Whether to build wheels for platforms that require emulation"
+        default: true
+        type: boolean
 
 jobs:
   build_sdist:
@@ -128,7 +132,7 @@ jobs:
           path: wheelhouse/*.whl
 
   build_wheels_emulation:
-    if: ${{ !inputs.pure-python }}
+    if: ${{ !inputs.pure-python && inputs.build-emulated-wheels }}
     name: 🎡 ${{ matrix.arch }}
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
This PR adds a `build-emulated-wheels` option to the `reusable-python-packaging` workflow that defaults to `true` and controls whether the emulated wheel builds are triggered.
Given that these builds take quite a while, it might be wise to turn them off for continuous deployments, e.g., from every push to main. 