### PR TITLE
❓ add change detection for running continuous deployment

### DIFF
--- a/.github/workflows/reusable-change-detection.yml
+++ b/.github/workflows/reusable-change-detection.yml
@@ -17,6 +17,9 @@ on:
       run-code-ql:
         description: Whether to run CodeQL
         value: ${{ jobs.change-detection.outputs.run-code-ql || false }}
+      run-cd:
+        description: Whether to run the continuous deployment job
+        value: ${{ jobs.change-detection.outputs.run-cd || false }}
 
 jobs:
   change-detection:
@@ -28,6 +31,7 @@ jobs:
       run-cpp-linter: ${{ steps.cpp-linter-changes.outputs.run-cpp-linter || false }}
       run-python-tests: ${{ steps.python-tests-changes.outputs.run-python-tests || false }}
       run-code-ql: ${{ steps.code-ql-changes.outputs.run-code-ql || false }}
+      run-cd: ${{ steps.cd-changes.outputs.run-cd || false }}
     steps:
       - uses: actions/checkout@v4
       - name: Get a list of the changed files relevant for the C++ tests
@@ -136,3 +140,17 @@ jobs:
         id: code-ql-changes
         run: >-
           echo "run-code-ql=true" >> "${GITHUB_OUTPUT}"
+      - name: Get a list of the changed files relevant for the continuous deployment job
+        if: github.event_name == 'pull_request'
+        id: changed-cd-files
+        uses: Ana06/get-changed-files@v2.3.0
+        with:
+          filter: |
+            .github/workflows/cd.yml
+      - name: Set a flag for running the continuous deployment job
+        if: >-
+          github.event_name != 'pull_request'
+          || steps.changed-cd-files.outputs.added_modified_renamed != ''
+        id: cd-changes
+        run: >-
+          echo "run-cd=true" >> "${GITHUB_OUTPUT}"


### PR DESCRIPTION
This PR adds another output to the `reusable-change-detection` workflow that indicates whether continuous deployment should be run. The output is `true` whenever the `.github/workflows/cd.yml` file changes in a PR or when not in a PR, e.g., on pushes to main.
This allows to incorporate the CD job in the branch protection workflow and to ensure that all the jobs pass whenever the job is run as part of the CI checks on a PR.