### PR TITLE
🔧 add a configuration option to turn off local versioning

### DIFF
--- a/.github/workflows/reusable-python-packaging.yml
+++ b/.github/workflows/reusable-python-packaging.yml
@@ -19,6 +19,10 @@ on:
         description: "Whether to build wheels for platforms that require emulation"
         default: true
         type: boolean
+      no-local-version:
+        description: "Whether to configure setuptools_scm to not use local version identifiers"
+        default: false
+        type: boolean
 
 jobs:
   build_sdist:
@@ -36,6 +40,24 @@ jobs:
         with:
           version: "latest"
           enable-cache: true
+      # workaround for https://github.com/pypa/setuptools-scm/issues/455
+      - if: ${{ inputs.no-local-version }}
+        name: Disable local version identifiers for setuptools_scm
+        run: |
+          uv run --no-project --with tomlkit - <<'EOF'
+          from pathlib import Path
+          import tomlkit
+
+          pyproject_toml_path = Path.cwd() / "pyproject.toml"
+          pyproject_toml_txt = pyproject_toml_path.read_text()
+          pyproject_toml = tomlkit.loads(pyproject_toml_txt)
+          setuptools_scm_section = pyproject_toml["tool"]["setuptools_scm"]
+          setuptools_scm_section["local_scheme"] = "no-local-version"
+          patched_pyproject_toml_txt = tomlkit.dumps(pyproject_toml)
+          pyproject_toml_path.write_text(patched_pyproject_toml_txt)
+          EOF
+          git diff --color=always
+          git update-index --assume-unchanged pyproject.toml
       # build the source distribution
       - name: Build SDist
         run: uv build --sdist
@@ -64,6 +86,24 @@ jobs:
         with:
           version: "latest"
           enable-cache: true
+      # workaround for https://github.com/pypa/setuptools-scm/issues/455
+      - if: ${{ inputs.no-local-version }}
+        name: Disable local version identifiers for setuptools_scm
+        run: |
+          uv run --no-project --with tomlkit - <<'EOF'
+          from pathlib import Path
+          import tomlkit
+
+          pyproject_toml_path = Path.cwd() / "pyproject.toml"
+          pyproject_toml_txt = pyproject_toml_path.read_text()
+          pyproject_toml = tomlkit.loads(pyproject_toml_txt)
+          setuptools_scm_section = pyproject_toml["tool"]["setuptools_scm"]
+          setuptools_scm_section["local_scheme"] = "no-local-version"
+          patched_pyproject_toml_txt = tomlkit.dumps(pyproject_toml)
+          pyproject_toml_path.write_text(patched_pyproject_toml_txt)
+          EOF
+          git diff --color=always
+          git update-index --assume-unchanged pyproject.toml
       # build the wheel
       - name: Build Wheel
         run: uv build --wheel
@@ -113,12 +153,30 @@ jobs:
           windows_compile_environment: msvc
           override_cache_key: wheels-${{ matrix.runs-on }}
       # set up uv for faster Python package management
-      - if: matrix.runs-on != 'ubuntu-latest'
-        name: Install the latest version of uv
+      - name: Install the latest version of uv
         uses: astral-sh/setup-uv@v3
         with:
           version: "latest"
           enable-cache: true
+      # workaround for https://github.com/pypa/setuptools-scm/issues/455
+      - if: ${{ inputs.no-local-version }}
+        name: Disable local version identifiers for setuptools_scm
+        shell: bash
+        run: |
+          uv run --no-project --with tomlkit - <<'EOF'
+          from pathlib import Path
+          import tomlkit
+
+          pyproject_toml_path = Path.cwd() / "pyproject.toml"
+          pyproject_toml_txt = pyproject_toml_path.read_text()
+          pyproject_toml = tomlkit.loads(pyproject_toml_txt)
+          setuptools_scm_section = pyproject_toml["tool"]["setuptools_scm"]
+          setuptools_scm_section["local_scheme"] = "no-local-version"
+          patched_pyproject_toml_txt = tomlkit.dumps(pyproject_toml)
+          pyproject_toml_path.write_text(patched_pyproject_toml_txt)
+          EOF
+          git diff --color=always
+          git update-index --assume-unchanged pyproject.toml
       # run cibuildwheel to build wheels for the specified Python version
       - uses: pypa/cibuildwheel@v2.21
       - name: Verify clean directory
@@ -154,6 +212,30 @@ jobs:
         name: Set environment variables for Z3 installation in manylinux image
         run: |
           echo "CIBW_BEFORE_ALL_LINUX=/opt/python/cp311-cp311/bin/pip install z3-solver==${{ inputs.z3-version }}" >> $GITHUB_ENV
+      # set up uv for faster Python package management
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          version: "latest"
+          enable-cache: true
+      # workaround for https://github.com/pypa/setuptools-scm/issues/455
+      - if: ${{ inputs.no-local-version }}
+        name: Disable local version identifiers for setuptools_scm
+        run: |
+          uv run --no-project --with tomlkit - <<'EOF'
+          from pathlib import Path
+          import tomlkit
+
+          pyproject_toml_path = Path.cwd() / "pyproject.toml"
+          pyproject_toml_txt = pyproject_toml_path.read_text()
+          pyproject_toml = tomlkit.loads(pyproject_toml_txt)
+          setuptools_scm_section = pyproject_toml["tool"]["setuptools_scm"]
+          setuptools_scm_section["local_scheme"] = "no-local-version"
+          patched_pyproject_toml_txt = tomlkit.dumps(pyproject_toml)
+          pyproject_toml_path.write_text(patched_pyproject_toml_txt)
+          EOF
+          git diff --color=always
+          git update-index --assume-unchanged pyproject.toml
       # run cibuildwheel to build wheels for the specified Python version
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.21


### PR DESCRIPTION
This PR adds a configuration option for turning off local versioning for `setuptools_scm`. This aids in creating development versions for TestPyPI during continuous deployment, e.g., for every push to main.
PyPI does not allow for local version fragments in version numbers when uploading packages. Thus, this option is disabled if the corresponding `no-local-version` workflow input is set to `true`.

A good default for consuming workflows is
```yaml
no-local-version: ${{ github.ref == 'refs/heads/main' && github.event_name == 'push' }}
```