### PR TITLE
🔧 only indicate a CD run on PRs that change the `cd.yml` workflow

### DIFF
--- a/.github/workflows/reusable-change-detection.yml
+++ b/.github/workflows/reusable-change-detection.yml
@@ -148,9 +148,7 @@ jobs:
           filter: |
             .github/workflows/cd.yml
       - name: Set a flag for running the continuous deployment job
-        if: >-
-          github.event_name != 'pull_request'
-          || steps.changed-cd-files.outputs.added_modified_renamed != ''
+        if: steps.changed-cd-files.outputs.added_modified_renamed != ''
         id: cd-changes
         run: >-
           echo "run-cd=true" >> "${GITHUB_OUTPUT}"


### PR DESCRIPTION
Another small follow-up towards enabling TestPyPI deployments. Change detection now only indicates the CD workflow to run on PRs that change the `cd.yml` workflow.