### PR TITLE
🚸 run Python tests on changes to the `uv` lock file

### DIFF
--- a/.github/workflows/reusable-change-detection.yml
+++ b/.github/workflows/reusable-change-detection.yml
@@ -102,6 +102,7 @@ jobs:
             test/python/**
             noxfile.py
             pyproject.toml
+            uv.lock
             CMakeLists.txt
             .github/codecov.yml
             .github/workflows/reusable-python-linter.yml


### PR DESCRIPTION
This small PR ensures that Python testing is run whenever the `uv` lock file changes.