### PR TITLE
🛂 ensure right permissions for workflows

### DIFF
--- a/.github/workflows/reusable-cpp-coverage.yml
+++ b/.github/workflows/reusable-cpp-coverage.yml
@@ -20,7 +20,8 @@ jobs:
     name: 📈 Coverage
     runs-on: ubuntu-latest
     permissions:
-      id-token: write
+      contents: read # Required for the `actions/checkout` action
+      id-token: write # Required for the `codecov/codecov-action` action
     env:
       CMAKE_BUILD_PARALLEL_LEVEL: 4
       CTEST_PARALLEL_LEVEL: 4

--- a/.github/workflows/reusable-python-ci.yml
+++ b/.github/workflows/reusable-python-ci.yml
@@ -57,7 +57,8 @@ jobs:
     needs: [python-tests]
     runs-on: ubuntu-latest
     permissions:
-      id-token: write
+      contents: read # Required for the `actions/checkout` action
+      id-token: write # Required for the `codecov/codecov-action` action
     steps:
       # check out the repository (mostly for the codecov config)
       - uses: actions/checkout@v4


### PR DESCRIPTION
This small PR ensures that the right permissions are set for the workflows handling coverage data.
When setting any kind of permission, all others default to `none`. Hence, `contents: read` needs to be set explicitly for the checkout to work.