### PR TITLE
🚑 workaround for codecov regression when using OIDC

### DIFF
--- a/.github/workflows/reusable-cpp-coverage.yml
+++ b/.github/workflows/reusable-cpp-coverage.yml
@@ -56,4 +56,4 @@ jobs:
         with:
           fail_ci_if_error: true
           flags: cpp
-          use_oidc: true
+          use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}

--- a/.github/workflows/reusable-python-ci.yml
+++ b/.github/workflows/reusable-python-ci.yml
@@ -73,4 +73,4 @@ jobs:
         with:
           fail_ci_if_error: true
           flags: python
-          use_oidc: true
+          use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}


### PR DESCRIPTION
A follow up to #46 that addresses the codecov regression reported in https://github.com/codecov/codecov-action/issues/1594.
This should just be a temporary workaround until the regression has been resolved.
After this, coverage uploads from forks should work properly again.