### PR TITLE
🔧 also detect common other Python test changes

### DIFF
--- a/.github/workflows/reusable-change-detection.yml
+++ b/.github/workflows/reusable-change-detection.yml
@@ -99,7 +99,8 @@ jobs:
             extern/**
             include/**
             src/**
-            test/python/**
+            test/**/*.py
+            tests/**/*.py
             noxfile.py
             pyproject.toml
             uv.lock


### PR DESCRIPTION
This small PR adjusts the change detection workflow to also detect Python test releated changes from project structures mostly used for pure Python projects.