### PR TITLE
👷 adding GitHub's new Ubuntu ARM runners to the workflows

### DIFF
--- a/.github/workflows/reusable-cpp-tests-ubuntu.yml
+++ b/.github/workflows/reusable-cpp-tests-ubuntu.yml
@@ -21,8 +21,12 @@ on:
 
 jobs:
   cpp-tests-ubuntu:
-    name: 🐧 ${{ inputs.config }}
-    runs-on: ubuntu-latest
+    name: 🐧 ${{ matrix.runs-on }} ${{ inputs.config }}
+    runs-on: ${{ matrix.runs-on }}
+    strategy:
+      matrix:
+        runs-on: [ubuntu-24.04, ubuntu-24.04-arm]
+      fail-fast: false # Continue with other jobs if one fails
     env:
       CMAKE_BUILD_PARALLEL_LEVEL: 4
       CTEST_PARALLEL_LEVEL: 4

--- a/.github/workflows/reusable-python-ci.yml
+++ b/.github/workflows/reusable-python-ci.yml
@@ -62,7 +62,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [ubuntu-latest, macos-13, macos-14, windows-latest]
+        runs-on:
+          [ubuntu-24.04, ubuntu-24.04-arm, macos-13, macos-14, windows-latest]
     uses: ./.github/workflows/reusable-python-tests.yml
     with:
       runs-on: ${{ matrix.runs-on }}
@@ -76,7 +77,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [ubuntu-latest, macos-13, macos-14, windows-latest]
+        runs-on:
+          [ubuntu-24.04, ubuntu-24.04-arm, macos-13, macos-14, windows-latest]
         python-version: ${{ fromJson(needs.dist.outputs.python-versions) }}
         session: ["minimums", "tests"]
     uses: ./.github/workflows/reusable-python-tests-individual.yml

--- a/.github/workflows/reusable-python-packaging.yml
+++ b/.github/workflows/reusable-python-packaging.yml
@@ -123,7 +123,8 @@ jobs:
       fail-fast: false
       matrix:
         # build wheels for all supported Python versions on all platforms
-        runs-on: [ubuntu-latest, macos-13, macos-14, windows-latest]
+        runs-on:
+          [ubuntu-24.04, ubuntu-24.04-arm, macos-13, macos-14, windows-latest]
     steps:
       # check out the repository (including submodules and all history)
       - uses: actions/checkout@v4
@@ -196,7 +197,7 @@ jobs:
       fail-fast: false
       matrix:
         # build wheels for all supported Python versions on all platforms that require emulation
-        arch: ["s390x", "ppc64le", "aarch64"]
+        arch: ["s390x", "ppc64le"]
     steps:
       # check out the repository (including submodules and all history)
       - uses: actions/checkout@v4


### PR DESCRIPTION
GitHub now provides free Ubuntu ARM runners: https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview :tada:

This PR adds the respective runners to the C++ tests, the Python tests, as well as the Python CD configuration.
This effectively removes one of the platforms that previously required emulation (`aarch64`), which is great to see.

The new runners are enabled by default and, at the moment, I did not add a way to opt out of using them. Let's see how smooth using them turns out to be.