### PR TITLE
🔧 do not explicitly set the `uv` version to `latest`

### DIFF
--- a/.github/workflows/reusable-python-linter.yml
+++ b/.github/workflows/reusable-python-linter.yml
@@ -40,8 +40,6 @@ jobs:
       # set up uv for faster Python package management
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@v5
-        with:
-          version: "latest"
       - name: Run mypy
         run: uvx --with pre-commit-uv pre-commit run -a mypy
       # run check-sdist to ensure the package sdist is correct

--- a/.github/workflows/reusable-python-packaging.yml
+++ b/.github/workflows/reusable-python-packaging.yml
@@ -37,9 +37,6 @@ jobs:
       # set up uv for faster Python package management
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@v5
-        with:
-          version: "latest"
-          enable-cache: true
       # workaround for https://github.com/pypa/setuptools-scm/issues/455
       - if: ${{ inputs.no-local-version }}
         name: Disable local version identifiers for setuptools_scm
@@ -83,8 +80,6 @@ jobs:
       # set up uv for faster Python package management
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@v5
-        with:
-          version: "latest"
       # workaround for https://github.com/pypa/setuptools-scm/issues/455
       - if: ${{ inputs.no-local-version }}
         name: Disable local version identifiers for setuptools_scm
@@ -155,7 +150,6 @@ jobs:
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@v5
         with:
-          version: "latest"
           enable-cache: ${{ matrix.runs-on != 'ubuntu-latest' }}
       # workaround for https://github.com/pypa/setuptools-scm/issues/455
       - if: ${{ inputs.no-local-version }}
@@ -215,7 +209,6 @@ jobs:
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@v5
         with:
-          version: "latest"
           enable-cache: false
       # workaround for https://github.com/pypa/setuptools-scm/issues/455
       - if: ${{ inputs.no-local-version }}

--- a/.github/workflows/reusable-python-tests-individual.yml
+++ b/.github/workflows/reusable-python-tests-individual.yml
@@ -57,8 +57,6 @@ jobs:
       # set up uv for faster Python package management
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@v5
-        with:
-          version: "latest"
       # run the nox session (assumes a corresponding nox session exists) with coverage
       - name: Test on 🐍 ${{ inputs.python-version }}
         run: uvx nox -s ${{ inputs.session }}-${{ inputs.python-version }} --verbose -- --cov --cov-report=xml:coverage-${{ inputs.session }}-${{ inputs.python-version }}-${{ inputs.runs-on }}.xml

--- a/.github/workflows/reusable-python-tests.yml
+++ b/.github/workflows/reusable-python-tests.yml
@@ -49,8 +49,6 @@ jobs:
       # set up uv for faster Python package management
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@v5
-        with:
-          version: "latest"
       # set up nox for convenient testing
       - uses: wntrblm/nox@2024.10.09
       # run the nox minimums session (assumes a nox session named "minimums" exists) with coverage


### PR DESCRIPTION
The `setup-uv` action has added a way to infer the `uv` version from a respective configuration for the required uv version in the projects themselves.

The following can be placed in `pyproject.toml` to regulate the required version:

```toml
[tool.uv]
required-version = ">=0.5.20"
```