### PR TITLE
👷🐧🍎🏁 Extensive CI testing

### DIFF
--- a/.github/workflows/reusable-cpp-ci.yml
+++ b/.github/workflows/reusable-cpp-ci.yml
@@ -2,20 +2,11 @@ name: 🇨‌ • CI
 on:
   workflow_call:
     inputs:
+      ###---- General inputs ----------------------------------------------------------------------------------------###
       cmake-args:
-        description: "Additional arguments to pass to CMake on every OS"
-        default: "-G Ninja"
-        type: string
-      cmake-args-ubuntu:
-        description: "Additional arguments to pass to CMake on Ubuntu"
-        default: ""
-        type: string
-      cmake-args-macos:
-        description: "Additional arguments to pass to CMake on macOS"
-        default: ""
-        type: string
-      cmake-args-windows:
-        description: "Additional arguments to pass to CMake on Windows"
+        description: >
+          Additional arguments to pass to CMake on every OS. Defaults to an empty string.
+          This can be any valid CMake argument, such as '-DBUILD_SHARED_LIBS=ON'.
         default: ""
         type: string
       setup-z3:
@@ -26,42 +17,365 @@ on:
         description: "The version of Z3 to set up"
         default: "4.13.0"
         type: string
+      ###---- Ubuntu-specific inputs --------------------------------------------------------------------------------###
+      ### Runs (ubuntu-24.04, ubuntu-22.04, ubuntu-24.04-arm, ubuntu-22.04-arm) x (gcc, clang) x (Release, Debug)
+      ### Defaults are
+      ### - ubuntu-24.04, gcc, Release,
+      ### - ubuntu-22.04, gcc, Release,
+      ### - ubuntu-24.04-arm, gcc, Release,
+      ### - ubuntu-22.04-arm, gcc, Release,
+      ###------------------------------------------------------------------------------------------------------------###
+      enable-ubuntu:
+        description: "Whether to enable C++ testing on Ubuntu"
+        default: true
+        type: boolean
+      enable-ubuntu2404-gcc-release:
+        description: "Whether to enable C++ testing on Ubuntu 24.04 with GCC in Release mode"
+        default: true
+        type: boolean
+      enable-ubuntu2404-gcc-debug:
+        description: "Whether to enable C++ testing on Ubuntu 24.04 with GCC in Debug mode"
+        default: false
+        type: boolean
+      enable-ubuntu2404-clang-release:
+        description: "Whether to enable C++ testing on Ubuntu 24.04 with Clang in Release mode"
+        default: false
+        type: boolean
+      enable-ubuntu2404-clang-debug:
+        description: "Whether to enable C++ testing on Ubuntu 24.04 with Clang in Debug mode"
+        default: false
+        type: boolean
+      enable-ubuntu2204-gcc-release:
+        description: "Whether to enable C++ testing on Ubuntu 22.04 with GCC in Release mode"
+        default: false
+        type: boolean
+      enable-ubuntu2204-gcc-debug:
+        description: "Whether to enable C++ testing on Ubuntu 22.04 with GCC in Debug mode"
+        default: false
+        type: boolean
+      enable-ubuntu2204-clang-release:
+        description: "Whether to enable C++ testing on Ubuntu 22.04 with Clang in Release mode"
+        default: false
+        type: boolean
+      enable-ubuntu2204-clang-debug:
+        description: "Whether to enable C++ testing on Ubuntu 22.04 with Clang in Debug mode"
+        default: false
+        type: boolean
+      enable-ubuntu2404-arm-gcc-release:
+        description: "Whether to enable C++ testing on Ubuntu 24.04 ARM with GCC in Release mode"
+        default: true
+        type: boolean
+      enable-ubuntu2404-arm-gcc-debug:
+        description: "Whether to enable C++ testing on Ubuntu 24.04 ARM with GCC in Debug mode"
+        default: false
+        type: boolean
+      enable-ubuntu2404-arm-clang-release:
+        description: "Whether to enable C++ testing on Ubuntu 24.04 ARM with Clang in Release mode"
+        default: false
+        type: boolean
+      enable-ubuntu2404-arm-clang-debug:
+        description: "Whether to enable C++ testing on Ubuntu 24.04 ARM with Clang in Debug mode"
+        default: false
+        type: boolean
+      enable-ubuntu2204-arm-gcc-release:
+        description: "Whether to enable C++ testing on Ubuntu 22.04 ARM with GCC in Release mode"
+        default: false
+        type: boolean
+      enable-ubuntu2204-arm-gcc-debug:
+        description: "Whether to enable C++ testing on Ubuntu 22.04 ARM with GCC in Debug mode"
+        default: false
+        type: boolean
+      enable-ubuntu2204-arm-clang-release:
+        description: "Whether to enable C++ testing on Ubuntu 22.04 ARM with Clang in Release mode"
+        default: false
+        type: boolean
+      enable-ubuntu2204-arm-clang-debug:
+        description: "Whether to enable C++ testing on Ubuntu 22.04 ARM with Clang in Debug mode"
+        default: false
+        type: boolean
+      cmake-args-ubuntu:
+        description: "Additional arguments to pass to CMake on Ubuntu"
+        default: ""
+        type: string
+      ###---- macOS-specific inputs ---------------------------------------------------------------------------------###
+      ### Runs (macos-13, macos-14, macos-15) x (clang, gcc) x (Release, Debug)
+      ### Defaults are
+      ### - macos-13, clang, Release,
+      ### - macos-14, clang, Release,
+      ###------------------------------------------------------------------------------------------------------------###
+      enable-macos:
+        description: "Whether to enable C++ testing on macOS"
+        default: true
+        type: boolean
+      enable-macos13-clang-release:
+        description: "Whether to enable C++ testing on macOS 13 with Apple Clang in Release mode"
+        default: true
+        type: boolean
+      enable-macos13-clang-debug:
+        description: "Whether to enable C++ testing on macOS 13 with Apple Clang in Debug mode"
+        default: false
+        type: boolean
+      enable-macos13-gcc-release:
+        description: "Whether to enable C++ testing on macOS 13 with GCC in Release mode"
+        default: false
+        type: boolean
+      enable-macos13-gcc-debug:
+        description: "Whether to enable C++ testing on macOS 13 with GCC in Debug mode"
+        default: false
+        type: boolean
+      enable-macos14-clang-release:
+        description: "Whether to enable C++ testing on macOS 14 with Apple Clang in Release mode"
+        default: true
+        type: boolean
+      enable-macos14-clang-debug:
+        description: "Whether to enable C++ testing on macOS 14 with Apple Clang in Debug mode"
+        default: true
+        type: boolean
+      enable-macos14-gcc-release:
+        description: "Whether to enable C++ testing on macOS 14 with GCC in Release mode"
+        default: false
+        type: boolean
+      enable-macos14-gcc-debug:
+        description: "Whether to enable C++ testing on macOS 14 with GCC in Debug mode"
+        default: false
+        type: boolean
+      enable-macos15-clang-release:
+        description: "Whether to enable C++ testing on macOS 15 with Apple Clang in Release mode"
+        default: false
+        type: boolean
+      enable-macos15-clang-debug:
+        description: "Whether to enable C++ testing on macOS 15 with Apple Clang in Debug mode"
+        default: false
+        type: boolean
+      enable-macos15-gcc-release:
+        description: "Whether to enable C++ testing on macOS 15 with GCC in Release mode"
+        default: false
+        type: boolean
+      enable-macos15-gcc-debug:
+        description: "Whether to enable C++ testing on macOS 15 with GCC in Debug mode"
+        default: false
+        type: boolean
+      cmake-args-macos:
+        description: "Additional arguments to pass to CMake on macOS"
+        default: ""
+        type: string
+      ###---- Windows-specific inputs -------------------------------------------------------------------------------###
+      ### Runs (windows-2022, windows-2025) x (msvc, clang) x (Release, Debug)
+      ### Defaults are
+      ### - windows-2022, msvc, Release,
+      ###------------------------------------------------------------------------------------------------------------###
+      enable-windows:
+        description: "Whether to enable C++ testing on Windows"
+        default: true
+        type: boolean
+      enable-windows2022-msvc-release:
+        description: "Whether to enable C++ testing on Windows 2022 with MSVC in Release mode"
+        default: true
+        type: boolean
+      enable-windows2022-msvc-debug:
+        description: "Whether to enable C++ testing on Windows 2022 with MSVC in Debug mode"
+        default: false
+        type: boolean
+      enable-windows2022-clang-release:
+        description: "Whether to enable C++ testing on Windows 2022 with Clang in Release mode"
+        default: false
+        type: boolean
+      enable-windows2022-clang-debug:
+        description: "Whether to enable C++ testing on Windows 2022 with Clang in Debug mode"
+        default: false
+        type: boolean
+      enable-windows2025-msvc-release:
+        description: "Whether to enable C++ testing on Windows 2025 with MSVC in Release mode"
+        default: false
+        type: boolean
+      enable-windows2025-msvc-debug:
+        description: "Whether to enable C++ testing on Windows 2025 with MSVC in Debug mode"
+        default: false
+        type: boolean
+      enable-windows2025-clang-release:
+        description: "Whether to enable C++ testing on Windows 2025 with Clang in Release mode"
+        default: false
+        type: boolean
+      enable-windows2025-clang-debug:
+        description: "Whether to enable C++ testing on Windows 2025 with Clang in Debug mode"
+        default: false
+        type: boolean
+      cmake-args-windows:
+        description: "Additional arguments to pass to CMake on Windows"
+        default: ""
+        type: string
 
 jobs:
+  build-matrices:
+    runs-on: ubuntu-latest
+    outputs:
+      ubuntu-matrix: ${{ steps.build-ubuntu-matrix.outputs.matrix }}
+      macos-matrix: ${{ steps.build-macos-matrix.outputs.matrix }}
+      windows-matrix: ${{ steps.build-windows-matrix.outputs.matrix }}
+    steps:
+      - id: build-ubuntu-matrix
+        run: |
+          matrix='[]'
+          if [ "${{ inputs.enable-ubuntu2404-gcc-release }}" == "true" ]; then
+            matrix=$(echo $matrix | jq '. += [{"runs-on": "ubuntu-24.04", "config": "Release", "compiler": "gcc"}]')
+          fi
+          if [ "${{ inputs.enable-ubuntu2404-gcc-debug }}" == "true" ]; then
+            matrix=$(echo $matrix | jq '. += [{"runs-on": "ubuntu-24.04", "config": "Debug", "compiler": "gcc"}]')
+          fi
+          if [ "${{ inputs.enable-ubuntu2404-clang-release }}" == "true" ]; then
+            matrix=$(echo $matrix | jq '. += [{"runs-on": "ubuntu-24.04", "config": "Release", "compiler": "clang"}]')
+          fi
+          if [ "${{ inputs.enable-ubuntu2404-clang-debug }}" == "true" ]; then
+            matrix=$(echo $matrix | jq '. += [{"runs-on": "ubuntu-24.04", "config": "Debug", "compiler": "clang"}]')
+          fi
+          if [ "${{ inputs.enable-ubuntu2204-gcc-release }}" == "true" ]; then
+            matrix=$(echo $matrix | jq '. += [{"runs-on": "ubuntu-22.04", "config": "Release", "compiler": "gcc"}]')
+          fi
+          if [ "${{ inputs.enable-ubuntu2204-gcc-debug }}" == "true" ]; then
+            matrix=$(echo $matrix | jq '. += [{"runs-on": "ubuntu-22.04", "config": "Debug", "compiler": "gcc"}]')
+          fi
+          if [ "${{ inputs.enable-ubuntu2204-clang-release }}" == "true" ]; then
+            matrix=$(echo $matrix | jq '. += [{"runs-on": "ubuntu-22.04", "config": "Release", "compiler": "clang"}]')
+          fi
+          if [ "${{ inputs.enable-ubuntu2204-clang-debug }}" == "true" ]; then
+            matrix=$(echo $matrix | jq '. += [{"runs-on": "ubuntu-22.04", "config": "Debug", "compiler": "clang"}]')
+          fi
+          if [ "${{ inputs.enable-ubuntu2404-arm-gcc-release }}" == "true" ]; then
+            matrix=$(echo $matrix | jq '. += [{"runs-on": "ubuntu-24.04-arm", "config": "Release", "compiler": "gcc"}]')
+          fi
+          if [ "${{ inputs.enable-ubuntu2404-arm-gcc-debug }}" == "true" ]; then
+            matrix=$(echo $matrix | jq '. += [{"runs-on": "ubuntu-24.04-arm", "config": "Debug", "compiler": "gcc"}]')
+          fi
+          if [ "${{ inputs.enable-ubuntu2404-arm-clang-release }}" == "true" ]; then
+            matrix=$(echo $matrix | jq '. += [{"runs-on": "ubuntu-24.04-arm", "config": "Release", "compiler": "clang"}]')
+          fi
+          if [ "${{ inputs.enable-ubuntu2404-arm-clang-debug }}" == "true" ]; then
+            matrix=$(echo $matrix | jq '. += [{"runs-on": "ubuntu-24.04-arm", "config": "Debug", "compiler": "clang"}]')
+          fi
+          if [ "${{ inputs.enable-ubuntu2204-arm-gcc-release }}" == "true" ]; then
+            matrix=$(echo $matrix | jq '. += [{"runs-on": "ubuntu-22.04-arm", "config": "Release", "compiler": "gcc"}]')
+          fi
+          if [ "${{ inputs.enable-ubuntu2204-arm-gcc-debug }}" == "true" ]; then
+            matrix=$(echo $matrix | jq '. += [{"runs-on": "ubuntu-22.04-arm", "config": "Debug", "compiler": "gcc"}]')
+          fi
+          if [ "${{ inputs.enable-ubuntu2204-arm-clang-release }}" == "true" ]; then
+            matrix=$(echo $matrix | jq '. += [{"runs-on": "ubuntu-22.04-arm", "config": "Release", "compiler": "clang"}]')
+          fi
+          if [ "${{ inputs.enable-ubuntu2204-arm-clang-debug }}" == "true" ]; then
+            matrix=$(echo $matrix | jq '. += [{"runs-on": "ubuntu-22.04-arm", "config": "Debug", "compiler": "clang"}]')
+          fi
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+      - id: build-macos-matrix
+        run: |
+          matrix='[]'
+          if [ "${{ inputs.enable-macos13-clang-release }}" == "true" ]; then
+            matrix=$(echo $matrix | jq '. += [{"runs-on": "macos-13", "config": "Release", "compiler": "clang"}]')
+          fi
+          if [ "${{ inputs.enable-macos13-clang-debug }}" == "true" ]; then
+            matrix=$(echo $matrix | jq '. += [{"runs-on": "macos-13", "config": "Debug", "compiler": "clang"}]')
+          fi
+          if [ "${{ inputs.enable-macos13-gcc-release }}" == "true" ]; then
+            matrix=$(echo $matrix | jq '. += [{"runs-on": "macos-13", "config": "Release", "compiler": "gcc"}]')
+          fi
+          if [ "${{ inputs.enable-macos13-gcc-debug }}" == "true" ]; then
+            matrix=$(echo $matrix | jq '. += [{"runs-on": "macos-13", "config": "Debug", "compiler": "gcc"}]')
+          fi
+          if [ "${{ inputs.enable-macos14-clang-release }}" == "true" ]; then
+            matrix=$(echo $matrix | jq '. += [{"runs-on": "macos-14", "config": "Release", "compiler": "clang"}]')
+          fi
+          if [ "${{ inputs.enable-macos14-clang-debug }}" == "true" ]; then
+            matrix=$(echo $matrix | jq '. += [{"runs-on": "macos-14", "config": "Debug", "compiler": "clang"}]')
+          fi
+          if [ "${{ inputs.enable-macos14-gcc-release }}" == "true" ]; then
+            matrix=$(echo $matrix | jq '. += [{"runs-on": "macos-14", "config": "Release", "compiler": "gcc"}]')
+          fi
+          if [ "${{ inputs.enable-macos14-gcc-debug }}" == "true" ]; then
+            matrix=$(echo $matrix | jq '. += [{"runs-on": "macos-14", "config": "Debug", "compiler": "gcc"}]')
+          fi
+          if [ "${{ inputs.enable-macos15-clang-release }}" == "true" ]; then
+            matrix=$(echo $matrix | jq '. += [{"runs-on": "macos-15", "config": "Release", "compiler": "clang"}]')
+          fi
+          if [ "${{ inputs.enable-macos15-clang-debug }}" == "true" ]; then
+            matrix=$(echo $matrix | jq '. += [{"runs-on": "macos-15", "config": "Debug", "compiler": "clang"}]')
+          fi
+          if [ "${{ inputs.enable-macos15-gcc-release }}" == "true" ]; then
+            matrix=$(echo $matrix | jq '. += [{"runs-on": "macos-15", "config": "Release", "compiler": "gcc"}]')
+          fi
+          if [ "${{ inputs.enable-macos15-gcc-debug }}" == "true" ]; then
+            matrix=$(echo $matrix | jq '. += [{"runs-on": "macos-15", "config": "Debug", "compiler": "gcc"}]')
+          fi
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+      - id: build-windows-matrix
+        run: |
+          matrix='[]'
+          if [ "${{ inputs.enable-windows2022-msvc-release }}" == "true" ]; then
+            matrix=$(echo $matrix | jq '. += [{"runs-on": "windows-2022", "config": "Release", "compiler": "msvc"}]')
+          fi
+          if [ "${{ inputs.enable-windows2022-msvc-debug }}" == "true" ]; then
+            matrix=$(echo $matrix | jq '. += [{"runs-on": "windows-2022", "config": "Debug", "compiler": "msvc"}]')
+          fi
+          if [ "${{ inputs.enable-windows2022-clang-release }}" == "true" ]; then
+            matrix=$(echo $matrix | jq '. += [{"runs-on": "windows-2022", "config": "Release", "compiler": "clang"}]')
+          fi
+          if [ "${{ inputs.enable-windows2022-clang-debug }}" == "true" ]; then
+            matrix=$(echo $matrix | jq '. += [{"runs-on": "windows-2022", "config": "Debug", "compiler": "clang"}]')
+          fi
+          if [ "${{ inputs.enable-windows2025-msvc-release }}" == "true" ]; then
+            matrix=$(echo $matrix | jq '. += [{"runs-on": "windows-2025", "config": "Release", "compiler": "msvc"}]')
+          fi
+          if [ "${{ inputs.enable-windows2025-msvc-debug }}" == "true" ]; then
+            matrix=$(echo $matrix | jq '. += [{"runs-on": "windows-2025", "config": "Debug", "compiler": "msvc"}]')
+          fi
+          if [ "${{ inputs.enable-windows2025-clang-release }}" == "true" ]; then
+            matrix=$(echo $matrix | jq '. += [{"runs-on": "windows-2025", "config": "Release", "compiler": "clang"}]')
+          fi
+          if [ "${{ inputs.enable-windows2025-clang-debug }}" == "true" ]; then
+            matrix=$(echo $matrix | jq '. += [{"runs-on": "windows-2025", "config": "Debug", "compiler": "clang"}]')
+          fi
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+
   cpp-tests-ubuntu:
-    name: 🐧 ${{ matrix.config }}
+    name: 🐧 ${{ matrix.runs-on }} ${{ matrix.compiler }} ${{ matrix.config }}
+    if: ${{ inputs.enable-ubuntu }}
+    needs: build-matrices
     strategy:
       matrix:
-        config: [Debug, Release]
+        include: ${{ fromJson(needs.build-matrices.outputs.ubuntu-matrix) }}
       fail-fast: false
     uses: ./.github/workflows/reusable-cpp-tests-ubuntu.yml
     with:
+      runs-on: ${{ matrix.runs-on }}
+      compiler: ${{ matrix.compiler }}
       config: ${{ matrix.config }}
       cmake-args: ${{ inputs.cmake-args }} ${{ inputs.cmake-args-ubuntu }}
       setup-z3: ${{ inputs.setup-z3 }}
       z3-version: ${{ inputs.z3-version }}
 
   cpp-tests-macos:
-    name: 🍎 ${{ matrix.config }}
+    name: 🍎 ${{ matrix.runs-on }} ${{ matrix.compiler }} ${{ matrix.config }}
     strategy:
       matrix:
-        config: [Debug, Release]
+        include: ${{ fromJson(needs.build-matrices.outputs.macos-matrix) }}
       fail-fast: false
     uses: ./.github/workflows/reusable-cpp-tests-macos.yml
     with:
+      runs-on: ${{ matrix.runs-on }}
+      compiler: ${{ matrix.compiler }}
       config: ${{ matrix.config }}
       cmake-args: ${{ inputs.cmake-args }} ${{ inputs.cmake-args-macos }}
       setup-z3: ${{ inputs.setup-z3 }}
       z3-version: ${{ inputs.z3-version }}
 
   cpp-tests-windows:
-    name: 🏁 ${{ matrix.config }}
+    name: 🏁 ${{ matrix.runs-on }} ${{ matrix.compiler }} ${{ matrix.config }}
     strategy:
       matrix:
-        config: [Debug, Release]
+        include: ${{ fromJson(needs.build-matrices.outputs.windows-matrix) }}
       fail-fast: false
     uses: ./.github/workflows/reusable-cpp-tests-windows.yml
     with:
+      runs-on: ${{ matrix.runs-on }}
+      compiler: ${{ matrix.compiler }}
       config: ${{ matrix.config }}
       cmake-args: ${{ inputs.cmake-args }} ${{ inputs.cmake-args-windows }}
       setup-z3: ${{ inputs.setup-z3 }}

--- a/.github/workflows/reusable-cpp-ci.yml
+++ b/.github/workflows/reusable-cpp-ci.yml
@@ -359,6 +359,8 @@ jobs:
 
   cpp-tests-macos:
     name: 🍎 ${{ matrix.runs-on }} ${{ matrix.compiler }} ${{ matrix.config }}
+    if: ${{ inputs.enable-macos }}
+    needs: build-matrices
     strategy:
       matrix:
         include: ${{ fromJson(needs.build-matrices.outputs.macos-matrix) }}
@@ -374,6 +376,8 @@ jobs:
 
   cpp-tests-windows:
     name: 🏁 ${{ matrix.runs-on }} ${{ matrix.compiler }} ${{ matrix.config }}
+    if: ${{ inputs.enable-windows }}
+    needs: build-matrices
     strategy:
       matrix:
         include: ${{ fromJson(needs.build-matrices.outputs.windows-matrix) }}

--- a/.github/workflows/reusable-cpp-ci.yml
+++ b/.github/workflows/reusable-cpp-ci.yml
@@ -209,130 +209,136 @@ jobs:
   build-matrices:
     runs-on: ubuntu-latest
     outputs:
-      ubuntu-matrix: ${{ steps.build-ubuntu-matrix.outputs.matrix }}
-      macos-matrix: ${{ steps.build-macos-matrix.outputs.matrix }}
-      windows-matrix: ${{ steps.build-windows-matrix.outputs.matrix }}
+      ubuntu-matrix: ${{ steps.build-ubuntu-matrix.outputs.ubuntu-matrix }}
+      macos-matrix: ${{ steps.build-macos-matrix.outputs.macos-matrix }}
+      windows-matrix: ${{ steps.build-windows-matrix.outputs.windows-matrix }}
     steps:
       - id: build-ubuntu-matrix
+        name: Build Ubuntu matrix
         run: |
-          matrix='[]'
+          ubuntu_matrix='[]'
           if [ "${{ inputs.enable-ubuntu2404-gcc-release }}" == "true" ]; then
-            matrix=$(echo $matrix | jq '. += [{"runs-on": "ubuntu-24.04", "config": "Release", "compiler": "gcc"}]')
+            ubuntu_matrix=$(echo $ubuntu_matrix | jq '. += [{"runs-on": "ubuntu-24.04", "config": "Release", "compiler": "gcc"}]')
           fi
           if [ "${{ inputs.enable-ubuntu2404-gcc-debug }}" == "true" ]; then
-            matrix=$(echo $matrix | jq '. += [{"runs-on": "ubuntu-24.04", "config": "Debug", "compiler": "gcc"}]')
+            ubuntu_matrix=$(echo $ubuntu_matrix | jq '. += [{"runs-on": "ubuntu-24.04", "config": "Debug", "compiler": "gcc"}]')
           fi
           if [ "${{ inputs.enable-ubuntu2404-clang-release }}" == "true" ]; then
-            matrix=$(echo $matrix | jq '. += [{"runs-on": "ubuntu-24.04", "config": "Release", "compiler": "clang"}]')
+            ubuntu_matrix=$(echo $ubuntu_matrix | jq '. += [{"runs-on": "ubuntu-24.04", "config": "Release", "compiler": "clang"}]')
           fi
           if [ "${{ inputs.enable-ubuntu2404-clang-debug }}" == "true" ]; then
-            matrix=$(echo $matrix | jq '. += [{"runs-on": "ubuntu-24.04", "config": "Debug", "compiler": "clang"}]')
+            ubuntu_matrix=$(echo $ubuntu_matrix | jq '. += [{"runs-on": "ubuntu-24.04", "config": "Debug", "compiler": "clang"}]')
           fi
           if [ "${{ inputs.enable-ubuntu2204-gcc-release }}" == "true" ]; then
-            matrix=$(echo $matrix | jq '. += [{"runs-on": "ubuntu-22.04", "config": "Release", "compiler": "gcc"}]')
+            ubuntu_matrix=$(echo $ubuntu_matrix | jq '. += [{"runs-on": "ubuntu-22.04", "config": "Release", "compiler": "gcc"}]')
           fi
           if [ "${{ inputs.enable-ubuntu2204-gcc-debug }}" == "true" ]; then
-            matrix=$(echo $matrix | jq '. += [{"runs-on": "ubuntu-22.04", "config": "Debug", "compiler": "gcc"}]')
+            ubuntu_matrix=$(echo $ubuntu_matrix | jq '. += [{"runs-on": "ubuntu-22.04", "config": "Debug", "compiler": "gcc"}]')
           fi
           if [ "${{ inputs.enable-ubuntu2204-clang-release }}" == "true" ]; then
-            matrix=$(echo $matrix | jq '. += [{"runs-on": "ubuntu-22.04", "config": "Release", "compiler": "clang"}]')
+            ubuntu_matrix=$(echo $ubuntu_matrix | jq '. += [{"runs-on": "ubuntu-22.04", "config": "Release", "compiler": "clang"}]')
           fi
           if [ "${{ inputs.enable-ubuntu2204-clang-debug }}" == "true" ]; then
-            matrix=$(echo $matrix | jq '. += [{"runs-on": "ubuntu-22.04", "config": "Debug", "compiler": "clang"}]')
+            ubuntu_matrix=$(echo $ubuntu_matrix | jq '. += [{"runs-on": "ubuntu-22.04", "config": "Debug", "compiler": "clang"}]')
           fi
           if [ "${{ inputs.enable-ubuntu2404-arm-gcc-release }}" == "true" ]; then
-            matrix=$(echo $matrix | jq '. += [{"runs-on": "ubuntu-24.04-arm", "config": "Release", "compiler": "gcc"}]')
+            ubuntu_matrix=$(echo $ubuntu_matrix | jq '. += [{"runs-on": "ubuntu-24.04-arm", "config": "Release", "compiler": "gcc"}]')
           fi
           if [ "${{ inputs.enable-ubuntu2404-arm-gcc-debug }}" == "true" ]; then
-            matrix=$(echo $matrix | jq '. += [{"runs-on": "ubuntu-24.04-arm", "config": "Debug", "compiler": "gcc"}]')
+            ubuntu_matrix=$(echo $ubuntu_matrix | jq '. += [{"runs-on": "ubuntu-24.04-arm", "config": "Debug", "compiler": "gcc"}]')
           fi
           if [ "${{ inputs.enable-ubuntu2404-arm-clang-release }}" == "true" ]; then
-            matrix=$(echo $matrix | jq '. += [{"runs-on": "ubuntu-24.04-arm", "config": "Release", "compiler": "clang"}]')
+            ubuntu_matrix=$(echo $ubuntu_matrix | jq '. += [{"runs-on": "ubuntu-24.04-arm", "config": "Release", "compiler": "clang"}]')
           fi
           if [ "${{ inputs.enable-ubuntu2404-arm-clang-debug }}" == "true" ]; then
-            matrix=$(echo $matrix | jq '. += [{"runs-on": "ubuntu-24.04-arm", "config": "Debug", "compiler": "clang"}]')
+            ubuntu_matrix=$(echo $ubuntu_matrix | jq '. += [{"runs-on": "ubuntu-24.04-arm", "config": "Debug", "compiler": "clang"}]')
           fi
           if [ "${{ inputs.enable-ubuntu2204-arm-gcc-release }}" == "true" ]; then
-            matrix=$(echo $matrix | jq '. += [{"runs-on": "ubuntu-22.04-arm", "config": "Release", "compiler": "gcc"}]')
+            ubuntu_matrix=$(echo $ubuntu_matrix | jq '. += [{"runs-on": "ubuntu-22.04-arm", "config": "Release", "compiler": "gcc"}]')
           fi
           if [ "${{ inputs.enable-ubuntu2204-arm-gcc-debug }}" == "true" ]; then
-            matrix=$(echo $matrix | jq '. += [{"runs-on": "ubuntu-22.04-arm", "config": "Debug", "compiler": "gcc"}]')
+            ubuntu_matrix=$(echo $ubuntu_matrix | jq '. += [{"runs-on": "ubuntu-22.04-arm", "config": "Debug", "compiler": "gcc"}]')
           fi
           if [ "${{ inputs.enable-ubuntu2204-arm-clang-release }}" == "true" ]; then
-            matrix=$(echo $matrix | jq '. += [{"runs-on": "ubuntu-22.04-arm", "config": "Release", "compiler": "clang"}]')
+            ubuntu_matrix=$(echo $ubuntu_matrix | jq '. += [{"runs-on": "ubuntu-22.04-arm", "config": "Release", "compiler": "clang"}]')
           fi
           if [ "${{ inputs.enable-ubuntu2204-arm-clang-debug }}" == "true" ]; then
-            matrix=$(echo $matrix | jq '. += [{"runs-on": "ubuntu-22.04-arm", "config": "Debug", "compiler": "clang"}]')
+            ubuntu_matrix=$(echo $ubuntu_matrix | jq '. += [{"runs-on": "ubuntu-22.04-arm", "config": "Debug", "compiler": "clang"}]')
           fi
-          echo "matrix=$(echo $matrix | jq -rc .)" >> $GITHUB_OUTPUT
+          echo "ubuntu-matrix=$(echo $ubuntu_matrix | jq -rc .)" >> $GITHUB_OUTPUT
+          echo $(echo $ubuntu_matrix | jq -rc .)
       - id: build-macos-matrix
+        name: Build macOS matrix
         run: |
-          matrix='[]'
+          macos_matrix='[]'
           if [ "${{ inputs.enable-macos13-clang-release }}" == "true" ]; then
-            matrix=$(echo $matrix | jq '. += [{"runs-on": "macos-13", "config": "Release", "compiler": "clang"}]')
+            macos_matrix=$(echo $macos_matrix | jq '. += [{"runs-on": "macos-13", "config": "Release", "compiler": "clang"}]')
           fi
           if [ "${{ inputs.enable-macos13-clang-debug }}" == "true" ]; then
-            matrix=$(echo $matrix | jq '. += [{"runs-on": "macos-13", "config": "Debug", "compiler": "clang"}]')
+            macos_matrix=$(echo $macos_matrix | jq '. += [{"runs-on": "macos-13", "config": "Debug", "compiler": "clang"}]')
           fi
           if [ "${{ inputs.enable-macos13-gcc-release }}" == "true" ]; then
-            matrix=$(echo $matrix | jq '. += [{"runs-on": "macos-13", "config": "Release", "compiler": "gcc"}]')
+            macos_matrix=$(echo $macos_matrix | jq '. += [{"runs-on": "macos-13", "config": "Release", "compiler": "gcc"}]')
           fi
           if [ "${{ inputs.enable-macos13-gcc-debug }}" == "true" ]; then
-            matrix=$(echo $matrix | jq '. += [{"runs-on": "macos-13", "config": "Debug", "compiler": "gcc"}]')
+            macos_matrix=$(echo $macos_matrix | jq '. += [{"runs-on": "macos-13", "config": "Debug", "compiler": "gcc"}]')
           fi
           if [ "${{ inputs.enable-macos14-clang-release }}" == "true" ]; then
-            matrix=$(echo $matrix | jq '. += [{"runs-on": "macos-14", "config": "Release", "compiler": "clang"}]')
+            macos_matrix=$(echo $macos_matrix | jq '. += [{"runs-on": "macos-14", "config": "Release", "compiler": "clang"}]')
           fi
           if [ "${{ inputs.enable-macos14-clang-debug }}" == "true" ]; then
-            matrix=$(echo $matrix | jq '. += [{"runs-on": "macos-14", "config": "Debug", "compiler": "clang"}]')
+            macos_matrix=$(echo $macos_matrix | jq '. += [{"runs-on": "macos-14", "config": "Debug", "compiler": "clang"}]')
           fi
           if [ "${{ inputs.enable-macos14-gcc-release }}" == "true" ]; then
-            matrix=$(echo $matrix | jq '. += [{"runs-on": "macos-14", "config": "Release", "compiler": "gcc"}]')
+            macos_matrix=$(echo $macos_matrix | jq '. += [{"runs-on": "macos-14", "config": "Release", "compiler": "gcc"}]')
           fi
           if [ "${{ inputs.enable-macos14-gcc-debug }}" == "true" ]; then
-            matrix=$(echo $matrix | jq '. += [{"runs-on": "macos-14", "config": "Debug", "compiler": "gcc"}]')
+            macos_matrix=$(echo $macos_matrix | jq '. += [{"runs-on": "macos-14", "config": "Debug", "compiler": "gcc"}]')
           fi
           if [ "${{ inputs.enable-macos15-clang-release }}" == "true" ]; then
-            matrix=$(echo $matrix | jq '. += [{"runs-on": "macos-15", "config": "Release", "compiler": "clang"}]')
+            macos_matrix=$(echo $macos_matrix | jq '. += [{"runs-on": "macos-15", "config": "Release", "compiler": "clang"}]')
           fi
           if [ "${{ inputs.enable-macos15-clang-debug }}" == "true" ]; then
-            matrix=$(echo $matrix | jq '. += [{"runs-on": "macos-15", "config": "Debug", "compiler": "clang"}]')
+            macos_matrix=$(echo $macos_matrix | jq '. += [{"runs-on": "macos-15", "config": "Debug", "compiler": "clang"}]')
           fi
           if [ "${{ inputs.enable-macos15-gcc-release }}" == "true" ]; then
-            matrix=$(echo $matrix | jq '. += [{"runs-on": "macos-15", "config": "Release", "compiler": "gcc"}]')
+            macos_matrix=$(echo $macos_matrix | jq '. += [{"runs-on": "macos-15", "config": "Release", "compiler": "gcc"}]')
           fi
           if [ "${{ inputs.enable-macos15-gcc-debug }}" == "true" ]; then
-            matrix=$(echo $matrix | jq '. += [{"runs-on": "macos-15", "config": "Debug", "compiler": "gcc"}]')
+            macos_matrix=$(echo $macos_matrix | jq '. += [{"runs-on": "macos-15", "config": "Debug", "compiler": "gcc"}]')
           fi
-          echo "matrix=$(echo $matrix | jq -rc .)" >> $GITHUB_OUTPUT
+          echo "macos-matrix=$(echo $macos_matrix | jq -rc .)" >> $GITHUB_OUTPUT
+          echo $(echo $macos_matrix | jq -rc .)
       - id: build-windows-matrix
+        name: Build Windows matrix
         run: |
-          matrix='[]'
+          windows_matrix='[]'
           if [ "${{ inputs.enable-windows2022-msvc-release }}" == "true" ]; then
-            matrix=$(echo $matrix | jq '. += [{"runs-on": "windows-2022", "config": "Release", "compiler": "msvc"}]')
+            windows_matrix=$(echo $windows_matrix | jq '. += [{"runs-on": "windows-2022", "config": "Release", "compiler": "msvc"}]')
           fi
           if [ "${{ inputs.enable-windows2022-msvc-debug }}" == "true" ]; then
-            matrix=$(echo $matrix | jq '. += [{"runs-on": "windows-2022", "config": "Debug", "compiler": "msvc"}]')
+            windows_matrix=$(echo $windows_matrix | jq '. += [{"runs-on": "windows-2022", "config": "Debug", "compiler": "msvc"}]')
           fi
           if [ "${{ inputs.enable-windows2022-clang-release }}" == "true" ]; then
-            matrix=$(echo $matrix | jq '. += [{"runs-on": "windows-2022", "config": "Release", "compiler": "clang"}]')
+            windows_matrix=$(echo $windows_matrix | jq '. += [{"runs-on": "windows-2022", "config": "Release", "compiler": "clang"}]')
           fi
           if [ "${{ inputs.enable-windows2022-clang-debug }}" == "true" ]; then
-            matrix=$(echo $matrix | jq '. += [{"runs-on": "windows-2022", "config": "Debug", "compiler": "clang"}]')
+            windows_matrix=$(echo $windows_matrix | jq '. += [{"runs-on": "windows-2022", "config": "Debug", "compiler": "clang"}]')
           fi
           if [ "${{ inputs.enable-windows2025-msvc-release }}" == "true" ]; then
-            matrix=$(echo $matrix | jq '. += [{"runs-on": "windows-2025", "config": "Release", "compiler": "msvc"}]')
+            windows_matrix=$(echo $windows_matrix | jq '. += [{"runs-on": "windows-2025", "config": "Release", "compiler": "msvc"}]')
           fi
           if [ "${{ inputs.enable-windows2025-msvc-debug }}" == "true" ]; then
-            matrix=$(echo $matrix | jq '. += [{"runs-on": "windows-2025", "config": "Debug", "compiler": "msvc"}]')
+            windows_matrix=$(echo $windows_matrix | jq '. += [{"runs-on": "windows-2025", "config": "Debug", "compiler": "msvc"}]')
           fi
           if [ "${{ inputs.enable-windows2025-clang-release }}" == "true" ]; then
-            matrix=$(echo $matrix | jq '. += [{"runs-on": "windows-2025", "config": "Release", "compiler": "clang"}]')
+            windows_matrix=$(echo $windows_matrix | jq '. += [{"runs-on": "windows-2025", "config": "Release", "compiler": "clang"}]')
           fi
           if [ "${{ inputs.enable-windows2025-clang-debug }}" == "true" ]; then
-            matrix=$(echo $matrix | jq '. += [{"runs-on": "windows-2025", "config": "Debug", "compiler": "clang"}]')
+            windows_matrix=$(echo $windows_matrix | jq '. += [{"runs-on": "windows-2025", "config": "Debug", "compiler": "clang"}]')
           fi
-          echo "matrix=$(echo $matrix | jq -rc .)" >> $GITHUB_OUTPUT
+          echo "windows-matrix=$(echo $windows_matrix | jq -rc .)" >> $GITHUB_OUTPUT
+          echo $(echo $windows_matrix | jq -rc .)
 
   cpp-tests-ubuntu:
     name: 🐧 ${{ matrix.runs-on }} ${{ matrix.compiler }} ${{ matrix.config }}

--- a/.github/workflows/reusable-cpp-ci.yml
+++ b/.github/workflows/reusable-cpp-ci.yml
@@ -264,7 +264,7 @@ jobs:
           if [ "${{ inputs.enable-ubuntu2204-arm-clang-debug }}" == "true" ]; then
             matrix=$(echo $matrix | jq '. += [{"runs-on": "ubuntu-22.04-arm", "config": "Debug", "compiler": "clang"}]')
           fi
-          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+          echo "matrix=$(echo $matrix | jq -rc .)" >> $GITHUB_OUTPUT
       - id: build-macos-matrix
         run: |
           matrix='[]'
@@ -304,7 +304,7 @@ jobs:
           if [ "${{ inputs.enable-macos15-gcc-debug }}" == "true" ]; then
             matrix=$(echo $matrix | jq '. += [{"runs-on": "macos-15", "config": "Debug", "compiler": "gcc"}]')
           fi
-          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+          echo "matrix=$(echo $matrix | jq -rc .)" >> $GITHUB_OUTPUT
       - id: build-windows-matrix
         run: |
           matrix='[]'
@@ -332,7 +332,7 @@ jobs:
           if [ "${{ inputs.enable-windows2025-clang-debug }}" == "true" ]; then
             matrix=$(echo $matrix | jq '. += [{"runs-on": "windows-2025", "config": "Debug", "compiler": "clang"}]')
           fi
-          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+          echo "matrix=$(echo $matrix | jq -rc .)" >> $GITHUB_OUTPUT
 
   cpp-tests-ubuntu:
     name: 🐧 ${{ matrix.runs-on }} ${{ matrix.compiler }} ${{ matrix.config }}

--- a/.github/workflows/reusable-cpp-ci.yml
+++ b/.github/workflows/reusable-cpp-ci.yml
@@ -380,11 +380,3 @@ jobs:
       cmake-args: ${{ inputs.cmake-args }} ${{ inputs.cmake-args-windows }}
       setup-z3: ${{ inputs.setup-z3 }}
       z3-version: ${{ inputs.z3-version }}
-
-  coverage:
-    name: 📈
-    uses: ./.github/workflows/reusable-cpp-coverage.yml
-    with:
-      cmake-args: ${{ inputs.cmake-args }} ${{ inputs.cmake-args-ubuntu }}
-      setup-z3: ${{ inputs.setup-z3 }}
-      z3-version: ${{ inputs.z3-version }}

--- a/.github/workflows/reusable-cpp-ci.yml
+++ b/.github/workflows/reusable-cpp-ci.yml
@@ -42,9 +42,14 @@ jobs:
       z3-version: ${{ inputs.z3-version }}
 
   cpp-tests-macos:
-    name: 🍎
+    name: 🍎 ${{ matrix.config }}
+    strategy:
+      matrix:
+        config: [Debug, Release]
+      fail-fast: false
     uses: ./.github/workflows/reusable-cpp-tests-macos.yml
     with:
+      config: ${{ matrix.config }}
       cmake-args: ${{ inputs.cmake-args }} ${{ inputs.cmake-args-macos }}
       setup-z3: ${{ inputs.setup-z3 }}
       z3-version: ${{ inputs.z3-version }}

--- a/.github/workflows/reusable-cpp-tests-macos.yml
+++ b/.github/workflows/reusable-cpp-tests-macos.yml
@@ -2,6 +2,10 @@ name: 🇨 • Tests • macos-latest
 on:
   workflow_call:
     inputs:
+      config:
+        description: "The configuration to use (Debug or Release)"
+        required: true
+        type: string
       cmake-args:
         description: "Additional arguments to pass to CMake"
         default: "-G Ninja"
@@ -17,11 +21,11 @@ on:
 
 jobs:
   cpp-tests-macos:
-    name: 🍎 ${{ matrix.runs-on }}
+    name: 🍎 ${{ matrix.runs-on }} ${{ inputs.config }}
     runs-on: ${{ matrix.runs-on }}
     strategy:
       matrix:
-        runs-on: [macos-13, macos-14] # Tests on the Intel and arm64 architectures
+        runs-on: [macos-13, macos-14, macos-15] # Tests on the Intel and arm64 architectures
       fail-fast: false # Continue with other jobs if one fails
     env:
       CMAKE_BUILD_PARALLEL_LEVEL: 4
@@ -44,28 +48,16 @@ jobs:
         uses: Chocobo1/setup-ccache-action@v1
         with:
           prepend_symlinks_to_path: false
-          override_cache_key: c++-tests-${{ matrix.runs-on }}
+          override_cache_key: c++-tests-${{ matrix.runs-on }}-${{ inputs.config }}
       # make sure ninja is installed
       - name: Install Ninja
         run: brew install ninja
-
-      # Runs tests in both, Debug and Release modes, on macOS. This reduces the number of concurrent runners needed.
-
-      # configure CMake in Debug mode, optionally with additional arguments
-      - name: Configure CMake (Debug)
-        run: cmake -S . -B build_debug -DCMAKE_BUILD_TYPE=Debug ${{ inputs.cmake-args }}
-      # build the project in Debug mode
-      - name: Build (Debug)
-        run: cmake --build build_debug --config Debug
-      # run the tests in Debug mode
-      - name: Test (Debug)
-        run: ctest -C Debug --output-on-failure --test-dir build_debug --repeat until-pass:3 --timeout 600
-      # configure CMake in Release mode, optionally with additional arguments
-      - name: Configure CMake (Release)
-        run: cmake -S . -B build_release -DCMAKE_BUILD_TYPE=Release ${{ inputs.cmake-args }}
-      # build the project in Release mode
-      - name: Build (Release)
-        run: cmake --build build_release --config Release
-      # run the tests in Release mode
-      - name: Test (Release)
-        run: ctest -C Release --output-on-failure --test-dir build_release --repeat until-pass:3 --timeout 600
+      # configure CMake in the specified mode, optionally with additional arguments
+      - name: Configure CMake
+        run: cmake -S . -B build -DCMAKE_BUILD_TYPE=${{ inputs.config }} ${{ inputs.cmake-args }}
+      # build the project in the specified mode
+      - name: Build
+        run: cmake --build build --config ${{ inputs.config }}
+      # run the tests
+      - name: Test
+        run: ctest -C ${{ inputs.config }} --output-on-failure --test-dir build --repeat until-pass:3 --timeout 600

--- a/.github/workflows/reusable-cpp-tests-macos.yml
+++ b/.github/workflows/reusable-cpp-tests-macos.yml
@@ -16,7 +16,7 @@ on:
         type: boolean
       z3-version:
         description: "The version of Z3 to set up"
-        default: "4.13.0"
+        default: "4.13.4"
         type: string
 
 jobs:

--- a/.github/workflows/reusable-cpp-tests-macos.yml
+++ b/.github/workflows/reusable-cpp-tests-macos.yml
@@ -2,13 +2,31 @@ name: 🇨 • Tests • macos-latest
 on:
   workflow_call:
     inputs:
+      runs-on:
+        description: >
+          The macOS runner image to use. Defaults to 'macos-latest'.
+          This can be any valid macOS runner image, such as 'macos-13', 'macos-14', or 'macos-15'.
+        default: "macos-latest"
+        type: string
       config:
-        description: "The configuration to use (Debug or Release)"
-        required: true
+        description: >
+          The build type to use. Defaults to 'Release'.
+          This can be any valid CMake build type, such as 'Debug' or 'Release'.
+        default: "Release"
+        type: string
+      compiler:
+        description: >
+          The compiler to use. Defaults to 'clang'.
+          This can be 'clang' or 'gcc'.
+          If 'clang' is selected, this will use the default Apple Clang compiler.
+          If 'gcc' is selected, this will use `gcc-14` from Homebrew, which is available by default on macOS runners.
+        default: "clang"
         type: string
       cmake-args:
-        description: "Additional arguments to pass to CMake"
-        default: "-G Ninja"
+        description: >
+          Additional arguments to pass to CMake. Defaults to an empty string.
+          This can be any valid CMake argument, such as '-DBUILD_SHARED_LIBS=ON'.
+        default: ""
         type: string
       setup-z3:
         description: "Whether to set up Z3"
@@ -21,12 +39,8 @@ on:
 
 jobs:
   cpp-tests-macos:
-    name: 🍎 ${{ matrix.runs-on }} ${{ inputs.config }}
-    runs-on: ${{ matrix.runs-on }}
-    strategy:
-      matrix:
-        runs-on: [macos-13, macos-14, macos-15] # Tests on the Intel and arm64 architectures
-      fail-fast: false # Continue with other jobs if one fails
+    name: 🍎 ${{ inputs.runs-on }} ${{ inputs.config }}
+    runs-on: ${{ inputs.runs-on }}
     env:
       CMAKE_BUILD_PARALLEL_LEVEL: 4
       CTEST_PARALLEL_LEVEL: 4
@@ -48,13 +62,18 @@ jobs:
         uses: Chocobo1/setup-ccache-action@v1
         with:
           prepend_symlinks_to_path: false
-          override_cache_key: c++-tests-${{ matrix.runs-on }}-${{ inputs.config }}
+          override_cache_key: c++-tests-${{ inputs.runs-on }}-${{ inputs.config }}-${{ inputs.compiler }}
       # make sure ninja is installed
       - name: Install Ninja
         run: brew install ninja
       # configure CMake in the specified mode, optionally with additional arguments
       - name: Configure CMake
-        run: cmake -S . -B build -DCMAKE_BUILD_TYPE=${{ inputs.config }} ${{ inputs.cmake-args }}
+        run: |
+          cmake_args="${{ inputs.cmake-args }}"
+          if [ "${{ inputs.compiler }}" == "gcc" ]; then
+            cmake_args="$cmake_args -DCMAKE_C_COMPILER=gcc-14 -DCMAKE_CXX_COMPILER=g++-14"
+          fi
+          cmake -G Ninja -S . -B build -DCMAKE_BUILD_TYPE=${{ inputs.config }} $cmake_args
       # build the project in the specified mode
       - name: Build
         run: cmake --build build --config ${{ inputs.config }}

--- a/.github/workflows/reusable-cpp-tests-macos.yml
+++ b/.github/workflows/reusable-cpp-tests-macos.yml
@@ -1,4 +1,4 @@
-name: 🇨 • Tests • macos-latest
+name: 🇨 • Tests • macos
 on:
   workflow_call:
     inputs:
@@ -39,7 +39,7 @@ on:
 
 jobs:
   cpp-tests-macos:
-    name: 🍎 ${{ inputs.runs-on }} ${{ inputs.config }}
+    name: 🍎 ${{ inputs.runs-on }} ${{ inputs.compiler }} ${{ inputs.config }}
     runs-on: ${{ inputs.runs-on }}
     env:
       CMAKE_BUILD_PARALLEL_LEVEL: 4

--- a/.github/workflows/reusable-cpp-tests-ubuntu.yml
+++ b/.github/workflows/reusable-cpp-tests-ubuntu.yml
@@ -2,13 +2,31 @@ name: 🇨 • Tests • ubuntu-latest
 on:
   workflow_call:
     inputs:
+      runs-on:
+        description: >
+          The ubuntu runner image to use. Defaults to 'ubuntu-latest'.
+          This can be any valid ubuntu runner image, such as 'ubuntu-22.04', 'ubuntu-24.04', or their ARM variants 'ubuntu-22.04-arm', 'ubuntu-24.04-arm'.
+        default: "ubuntu-latest"
+        type: string
       config:
-        description: "The configuration to use (Debug or Release)"
-        required: true
+        description: >
+          The build type to use. Defaults to 'Release'.
+          This can be any valid CMake build type, such as 'Debug' or 'Release'.
+        default: "Release"
+        type: string
+      compiler:
+        description: >
+          The compiler to use. Defaults to 'gcc'.
+          This can be 'gcc' or 'clang'.
+          If 'gcc' is selected, this will use the default GCC compiler.
+          If 'clang' is selected, this will use the default Clang compiler.
+        default: "gcc"
         type: string
       cmake-args:
-        description: "Additional arguments to pass to CMake"
-        default: "-G Ninja"
+        description: >
+          Additional arguments to pass to CMake. Defaults to an empty string.
+          This can be any valid CMake argument, such as '-DBUILD_SHARED_LIBS=ON'.
+        default: ""
         type: string
       setup-z3:
         description: "Whether to set up Z3"
@@ -21,13 +39,8 @@ on:
 
 jobs:
   cpp-tests-ubuntu:
-    name: 🐧 ${{ matrix.runs-on }} ${{ inputs.config }}
-    runs-on: ${{ matrix.runs-on }}
-    strategy:
-      matrix:
-        runs-on:
-          [ubuntu-22.04, ubuntu-24.04, ubuntu-22.04-arm, ubuntu-24.04-arm]
-      fail-fast: false # Continue with other jobs if one fails
+    name: 🐧 ${{ inputs.runs-on }} ${{ inputs.config }}
+    runs-on: ${{ inputs.runs-on }}
     env:
       CMAKE_BUILD_PARALLEL_LEVEL: 4
       CTEST_PARALLEL_LEVEL: 4
@@ -49,7 +62,7 @@ jobs:
         uses: Chocobo1/setup-ccache-action@v1
         with:
           prepend_symlinks_to_path: false
-          override_cache_key: c++-tests-${{ matrix.runs-on }}-${{ inputs.config }}
+          override_cache_key: c++-tests-${{ inputs.runs-on }}-${{ inputs.config }}-${{ inputs.compiler }}
       # set up mold as linker for faster C++ builds
       - name: Set up mold as linker
         uses: rui314/setup-mold@v1
@@ -58,7 +71,12 @@ jobs:
         run: pipx install ninja
       # configure CMake in the specified mode, optionally with additional arguments
       - name: Configure CMake
-        run: cmake -S . -B build -DCMAKE_BUILD_TYPE=${{ inputs.config }} ${{ inputs.cmake-args }}
+        run: |
+          cmake_args="${{ inputs.cmake-args }}"
+          if [ "${{ inputs.compiler }}" == "gcc" ]; then
+            cmake_args="$cmake_args -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++"
+          fi
+          cmake -G Ninja -S . -B build -DCMAKE_BUILD_TYPE=${{ inputs.config }} $cmake_args
       # build the project in the specified mode
       - name: Build
         run: cmake --build build --config ${{ inputs.config }}

--- a/.github/workflows/reusable-cpp-tests-ubuntu.yml
+++ b/.github/workflows/reusable-cpp-tests-ubuntu.yml
@@ -16,7 +16,7 @@ on:
         type: boolean
       z3-version:
         description: "The version of Z3 to set up"
-        default: "4.13.0"
+        default: "4.13.4"
         type: string
 
 jobs:

--- a/.github/workflows/reusable-cpp-tests-ubuntu.yml
+++ b/.github/workflows/reusable-cpp-tests-ubuntu.yml
@@ -25,7 +25,8 @@ jobs:
     runs-on: ${{ matrix.runs-on }}
     strategy:
       matrix:
-        runs-on: [ubuntu-24.04, ubuntu-24.04-arm]
+        runs-on:
+          [ubuntu-22.04, ubuntu-24.04, ubuntu-22.04-arm, ubuntu-24.04-arm]
       fail-fast: false # Continue with other jobs if one fails
     env:
       CMAKE_BUILD_PARALLEL_LEVEL: 4
@@ -48,7 +49,7 @@ jobs:
         uses: Chocobo1/setup-ccache-action@v1
         with:
           prepend_symlinks_to_path: false
-          override_cache_key: c++-tests-ubuntu-latest-${{ inputs.config }}
+          override_cache_key: c++-tests-${{ matrix.runs-on }}-${{ inputs.config }}
       # set up mold as linker for faster C++ builds
       - name: Set up mold as linker
         uses: rui314/setup-mold@v1

--- a/.github/workflows/reusable-cpp-tests-ubuntu.yml
+++ b/.github/workflows/reusable-cpp-tests-ubuntu.yml
@@ -1,4 +1,4 @@
-name: 🇨 • Tests • ubuntu-latest
+name: 🇨 • Tests • ubuntu
 on:
   workflow_call:
     inputs:
@@ -39,7 +39,7 @@ on:
 
 jobs:
   cpp-tests-ubuntu:
-    name: 🐧 ${{ inputs.runs-on }} ${{ inputs.config }}
+    name: 🐧 ${{ inputs.runs-on }} ${{ inputs.compiler }} ${{ inputs.config }}
     runs-on: ${{ inputs.runs-on }}
     env:
       CMAKE_BUILD_PARALLEL_LEVEL: 4

--- a/.github/workflows/reusable-cpp-tests-windows.yml
+++ b/.github/workflows/reusable-cpp-tests-windows.yml
@@ -49,13 +49,6 @@ jobs:
         uses: cda-tum/setup-z3@v1
         with:
           version: ${{ inputs.z3-version }}
-      # set up ccache for faster C++ builds
-      - name: Setup ccache
-        uses: Chocobo1/setup-ccache-action@v1
-        with:
-          prepend_symlinks_to_path: false
-          windows_compile_environment: msvc
-          override_cache_key: c++-tests-${{ matrix.runs-on }}-${{ inputs.config }}
       # configure CMake in the specified mode, optionally with additional arguments
       - name: Configure CMake
         run: cmake -S . -B build -DCMAKE_BUILD_TYPE=${{ inputs.config }} ${{ inputs.cmake-args }}

--- a/.github/workflows/reusable-cpp-tests-windows.yml
+++ b/.github/workflows/reusable-cpp-tests-windows.yml
@@ -2,13 +2,31 @@ name: 🇨 • Tests • windows-latest
 on:
   workflow_call:
     inputs:
+      runs-on:
+        description: >
+          The Windows runner image to use. Defaults to 'windows-latest'.
+          This can be any valid Windows runner image, such as 'windows-2022' or 'windows-2025'.
+        default: "windows-latest"
+        type: string
       config:
-        description: "The configuration to use (Debug or Release)"
-        required: true
+        description: >
+          The build type to use. Defaults to 'Release'.
+          This can be any valid CMake build type, such as 'Debug' or 'Release'.
+        default: "Release"
+        type: string
+      compiler:
+        description: >
+          The compiler to use. Defaults to 'msvc'.
+          This can be 'msvc' or 'clang'.
+          If 'msvc' is selected, '-G Ninja' is automatically added to the CMake arguments.
+          If 'clang' is selected, '-T ClangCL' is automatically added to the CMake arguments.
+        default: "msvc"
         type: string
       cmake-args:
-        description: "Additional arguments to pass to CMake"
-        default: "-G Ninja"
+        description: >
+          Additional arguments to pass to CMake. Defaults to an empty string.
+          This can be any valid CMake argument, such as '-DBUILD_SHARED_LIBS=ON'.
+        default: ""
         type: string
       setup-z3:
         description: "Whether to set up Z3"
@@ -25,12 +43,8 @@ defaults:
 
 jobs:
   cpp-tests-windows:
-    name: 🏁 ${{ matrix.runs-on }} ${{ inputs.config }}
-    runs-on: ${{ matrix.runs-on }}
-    strategy:
-      matrix:
-        runs-on: [windows-2022, windows-2025]
-      fail-fast: false # Continue with other jobs if one fails
+    name: 🏁 ${{ inputs.runs-on }} ${{ inputs.config }}
+    runs-on: ${{ inputs.runs-on }}
     env:
       CMAKE_BUILD_PARALLEL_LEVEL: 4
       CTEST_PARALLEL_LEVEL: 4
@@ -51,7 +65,14 @@ jobs:
           version: ${{ inputs.z3-version }}
       # configure CMake in the specified mode, optionally with additional arguments
       - name: Configure CMake
-        run: cmake -S . -B build -DCMAKE_BUILD_TYPE=${{ inputs.config }} ${{ inputs.cmake-args }}
+        run: |
+          cmake_args="${{ inputs.cmake-args }}"
+          if [ "${{ inputs.compiler }}" == "msvc" ]; then
+            cmake_args="$cmake_args -G Ninja"
+          elif [ "${{ inputs.compiler }}" == "clang" ]; then
+            cmake_args="$cmake_args -T ClangCL"
+          fi
+          cmake -S . -B build -DCMAKE_BUILD_TYPE=${{ inputs.config }} $cmake_args
       # build the project in the specified mode with retries
       - name: Build
         uses: nick-fields/retry@v3 # Windows builds with MSVC are flaky and frequently run out of heap space

--- a/.github/workflows/reusable-cpp-tests-windows.yml
+++ b/.github/workflows/reusable-cpp-tests-windows.yml
@@ -16,7 +16,7 @@ on:
         type: boolean
       z3-version:
         description: "The version of Z3 to set up"
-        default: "4.13.0"
+        default: "4.13.4"
         type: string
 
 defaults:

--- a/.github/workflows/reusable-cpp-tests-windows.yml
+++ b/.github/workflows/reusable-cpp-tests-windows.yml
@@ -1,4 +1,4 @@
-name: 🇨 • Tests • windows-latest
+name: 🇨 • Tests • windows
 on:
   workflow_call:
     inputs:
@@ -43,7 +43,7 @@ defaults:
 
 jobs:
   cpp-tests-windows:
-    name: 🏁 ${{ inputs.runs-on }} ${{ inputs.config }}
+    name: 🏁 ${{ inputs.runs-on }} ${{ inputs.compiler }} ${{ inputs.config }}
     runs-on: ${{ inputs.runs-on }}
     env:
       CMAKE_BUILD_PARALLEL_LEVEL: 4

--- a/.github/workflows/reusable-cpp-tests-windows.yml
+++ b/.github/workflows/reusable-cpp-tests-windows.yml
@@ -25,8 +25,12 @@ defaults:
 
 jobs:
   cpp-tests-windows:
-    name: 🏁 ${{ inputs.config }}
-    runs-on: windows-latest
+    name: 🏁 ${{ matrix.runs-on }} ${{ inputs.config }}
+    runs-on: ${{ matrix.runs-on }}
+    strategy:
+      matrix:
+        runs-on: [windows-2022, windows-2025]
+      fail-fast: false # Continue with other jobs if one fails
     env:
       CMAKE_BUILD_PARALLEL_LEVEL: 4
       CTEST_PARALLEL_LEVEL: 4
@@ -51,7 +55,7 @@ jobs:
         with:
           prepend_symlinks_to_path: false
           windows_compile_environment: msvc
-          override_cache_key: c++-tests-windows-latest-${{ inputs.config }}
+          override_cache_key: c++-tests-${{ matrix.runs-on }}-${{ inputs.config }}
       # configure CMake in the specified mode, optionally with additional arguments
       - name: Configure CMake
         run: cmake -S . -B build -DCMAKE_BUILD_TYPE=${{ inputs.config }} ${{ inputs.cmake-args }}

--- a/.github/workflows/reusable-python-ci.yml
+++ b/.github/workflows/reusable-python-ci.yml
@@ -3,8 +3,11 @@ name: 🐍 • CI
 on:
   workflow_call:
     inputs:
+      ###---- General inputs ----------------------------------------------------------------------------------------###
       skip-testing-latest-python:
-        description: "Whether to skip testing on the latest Python version. This only has an effect if the Python tests are run individually."
+        description: >
+          Whether to skip testing on the latest Python version.
+          This only has an effect if the Python tests are run individually.
         default: false
         type: boolean
       run-tests-individually:
@@ -19,6 +22,59 @@ on:
         description: "The version of Z3 to set up"
         default: "4.13.0"
         type: string
+      ###---- Ubuntu-specific inputs --------------------------------------------------------------------------------###
+      ### Runs (ubuntu-24.04, ubuntu-22.04, ubuntu-24.04-arm, ubuntu-22.04-arm)
+      ### Defaults are
+      ### - ubuntu-24.04
+      ### - ubuntu-24.04-arm
+      ###------------------------------------------------------------------------------------------------------------###
+      enable-ubuntu2404:
+        description: "Whether to enable the Ubuntu 24.04 runner"
+        default: true
+        type: boolean
+      enable-ubuntu2204:
+        description: "Whether to enable the Ubuntu 22.04 runner"
+        default: false
+        type: boolean
+      enable-ubuntu2404-arm:
+        description: "Whether to enable the Ubuntu 24.04 ARM runner"
+        default: true
+        type: boolean
+      enable-ubuntu2204-arm:
+        description: "Whether to enable the Ubuntu 22.04 ARM runner"
+        default: false
+        type: boolean
+      ###---- macOS-specific inputs ---------------------------------------------------------------------------------###
+      ### Runs (macos-13, macos-14, macos-15)
+      ### Defaults are
+      ### - macos-13
+      ### - macos-14
+      ###------------------------------------------------------------------------------------------------------------###
+      enable-macos13:
+        description: "Whether to enable the macOS 13 runner"
+        default: true
+        type: boolean
+      enable-macos14:
+        description: "Whether to enable the macOS 14 runner"
+        default: true
+        type: boolean
+      enable-macos15:
+        description: "Whether to enable the macOS 15 runner"
+        default: false
+        type: boolean
+      ###---- Windows-specific inputs -------------------------------------------------------------------------------###
+      ### Runs (windows-2022, windows-2025)
+      ### Defaults are
+      ### - windows-2022
+      ###------------------------------------------------------------------------------------------------------------###
+      enable-windows2022:
+        description: "Whether to enable the Windows 2022 runner"
+        default: true
+        type: boolean
+      enable-windows2025:
+        description: "Whether to enable the Windows 2025 runner"
+        default: false
+        type: boolean
 
 jobs:
   lint:
@@ -56,24 +112,53 @@ jobs:
     outputs:
       python-versions: ${{ steps.supported-python-versions.outputs.supported-python-versions }}
 
+  build-matrices:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.build-matrix.outputs.matrix }}
+    steps:
+      - id: build-matrix
+        name: Build runner matrix
+        run: |
+          matrix='[]'
+          if [ "${{ inputs.enable-ubuntu2404 }}" = "true" ]; then
+            matrix=$(echo $matrix | jq '. + [{"runs-on": "ubuntu-24.04"}]')
+          fi
+          if [ "${{ inputs.enable-ubuntu2204 }}" = "true" ]; then
+            matrix=$(echo $matrix | jq '. + [{"runs-on": "ubuntu-22.04"}]')
+          fi
+          if [ "${{ inputs.enable-ubuntu2404-arm }}" = "true" ]; then
+            matrix=$(echo $matrix | jq '. + [{"runs-on": "ubuntu-24.04-arm"}]')
+          fi
+          if [ "${{ inputs.enable-ubuntu2204-arm }}" = "true" ]; then
+            matrix=$(echo $matrix | jq '. + [{"runs-on": "ubuntu-22.04-arm"}]')
+          fi
+          if [ "${{ inputs.enable-macos13 }}" = "true" ]; then
+            matrix=$(echo $matrix | jq '. + [{"runs-on": "macos-13"}]')
+          fi
+          if [ "${{ inputs.enable-macos14 }}" = "true" ]; then
+            matrix=$(echo $matrix | jq '. + [{"runs-on": "macos-14"}]')
+          fi
+          if [ "${{ inputs.enable-macos15 }}" = "true" ]; then
+            matrix=$(echo $matrix | jq '. + [{"runs-on": "macos-15"}]')
+          fi
+          if [ "${{ inputs.enable-windows2022 }}" = "true" ]; then
+            matrix=$(echo $matrix | jq '. + [{"runs-on": "windows-2022"}]')
+          fi
+          if [ "${{ inputs.enable-windows2025 }}" = "true" ]; then
+            matrix=$(echo $matrix | jq '. + [{"runs-on": "windows-2025"}]')
+          fi
+          echo "matrix=$(echo $matrix | jq -rc .)" >> $GITHUB_OUTPUT
+          echo $(echo $matrix | jq -rc .)
+
   python-tests:
     if: ${{ !inputs.run-tests-individually }}
+    needs: [build-matrices]
     name: 🐍 ${{ matrix.runs-on }}
     strategy:
       fail-fast: false
       matrix:
-        runs-on:
-          [
-            ubuntu-22.04,
-            ubuntu-22.04-arm,
-            ubuntu-24.04,
-            ubuntu-24.04-arm,
-            macos-13,
-            macos-14,
-            macos-15,
-            windows-2022,
-            windows-2025,
-          ]
+        include: ${{ fromJson(needs.build-matrix.outputs.matrix) }}
     uses: ./.github/workflows/reusable-python-tests.yml
     with:
       runs-on: ${{ matrix.runs-on }}
@@ -82,23 +167,12 @@ jobs:
 
   python-tests-individual:
     if: ${{ inputs.run-tests-individually }}
-    needs: [dist]
-    name: 🐍 ${{ matrix.session }} ${{ matrix.python-version }} ${{ matrix.runs-on }}
+    needs: [build-matrices, dist]
+    name: 🐍 ${{ matrix.python-version }} ${{ matrix.runs-on }}
     strategy:
       fail-fast: false
       matrix:
-        runs-on:
-          [
-            ubuntu-22.04,
-            ubuntu-22.04-arm,
-            ubuntu-24.04,
-            ubuntu-24.04-arm,
-            macos-13,
-            macos-14,
-            macos-15,
-            windows-2022,
-            windows-2025,
-          ]
+        include: ${{ fromJson(needs.build-matrix.outputs.matrix) }}
         python-version: ${{ fromJson(needs.dist.outputs.python-versions) }}
     uses: ./.github/workflows/reusable-python-tests-individual.yml
     with:

--- a/.github/workflows/reusable-python-ci.yml
+++ b/.github/workflows/reusable-python-ci.yml
@@ -100,12 +100,10 @@ jobs:
             windows-2025,
           ]
         python-version: ${{ fromJson(needs.dist.outputs.python-versions) }}
-        session: ["minimums", "tests"]
     uses: ./.github/workflows/reusable-python-tests-individual.yml
     with:
       runs-on: ${{ matrix.runs-on }}
       python-version: ${{ matrix.python-version }}
-      session: ${{ matrix.session }}
       setup-z3: ${{ inputs.setup-z3 }}
       z3-version: ${{ inputs.z3-version }}
 

--- a/.github/workflows/reusable-python-ci.yml
+++ b/.github/workflows/reusable-python-ci.yml
@@ -4,16 +4,6 @@ on:
   workflow_call:
     inputs:
       ###---- General inputs ----------------------------------------------------------------------------------------###
-      skip-testing-latest-python:
-        description: >
-          Whether to skip testing on the latest Python version.
-          This only has an effect if the Python tests are run individually.
-        default: false
-        type: boolean
-      run-tests-individually:
-        description: "Whether to run the Python tests individually or combined"
-        default: false
-        type: boolean
       setup-z3:
         description: "Whether to set up Z3"
         default: false
@@ -77,41 +67,6 @@ on:
         type: boolean
 
 jobs:
-  lint:
-    name: 🚨 Lint
-    uses: ./.github/workflows/reusable-python-linter.yml
-    with:
-      setup-z3: ${{ inputs.setup-z3 }}
-      z3-version: ${{ inputs.z3-version }}
-
-  dist:
-    name: 📦 Check
-    runs-on: ubuntu-latest
-    steps:
-      # check out the repository (including submodules and all history)
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
-          fetch-depth: 0
-      # optionally set up Z3
-      - if: ${{ inputs.setup-z3 }}
-        name: Setup Z3
-        uses: cda-tum/setup-z3@v1
-        with:
-          version: ${{ inputs.z3-version }}
-      # set up mold as linker for faster C++ builds
-      - name: Set up mold as linker
-        uses: rui314/setup-mold@v1
-      # run the build-and-inspect-python-package action (outputs supported Python versions)
-      - uses: hynek/build-and-inspect-python-package@v2
-        id: baipp
-      # reduce the list of Python versions by one if the latest Python version is to be skipped
-      - name: 🐍 Conditionally reduce the list of considered Python versions
-        run: echo "supported-python-versions=$(echo '${{ steps.baipp.outputs.supported_python_classifiers_json_array }}' | jq -rc 'if ${{ inputs.skip-testing-latest-python }} then .[:-1] else . end')" >> $GITHUB_OUTPUT
-        id: supported-python-versions
-    outputs:
-      python-versions: ${{ steps.supported-python-versions.outputs.supported-python-versions }}
-
   build-matrices:
     runs-on: ubuntu-latest
     outputs:
@@ -152,7 +107,6 @@ jobs:
           echo $(echo $matrix | jq -rc .)
 
   python-tests:
-    if: ${{ !inputs.run-tests-individually }}
     needs: [build-matrices]
     name: 🐍 ${{ matrix.runs-on }}
     strategy:
@@ -165,50 +119,9 @@ jobs:
       setup-z3: ${{ inputs.setup-z3 }}
       z3-version: ${{ inputs.z3-version }}
 
-  python-tests-individual:
-    if: ${{ inputs.run-tests-individually }}
-    needs: [build-matrices, dist]
-    name: 🐍 ${{ matrix.python-version }} ${{ matrix.runs-on }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include: ${{ fromJson(needs.build-matrix.outputs.matrix) }}
-        python-version: ${{ fromJson(needs.dist.outputs.python-versions) }}
-    uses: ./.github/workflows/reusable-python-tests-individual.yml
-    with:
-      runs-on: ${{ matrix.runs-on }}
-      python-version: ${{ matrix.python-version }}
-      setup-z3: ${{ inputs.setup-z3 }}
-      z3-version: ${{ inputs.z3-version }}
-
   python-coverage-upload:
-    if: ${{ !inputs.run-tests-individually }}
     name: 📈
     needs: [python-tests]
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read # Required for the `actions/checkout` action
-      id-token: write # Required for the `codecov/codecov-action` action
-    steps:
-      # check out the repository (mostly for the codecov config)
-      - uses: actions/checkout@v4
-      # download coverage reports from all jobs
-      - uses: actions/download-artifact@v4
-        with:
-          pattern: coverage-*
-          path: coverage-reports
-          merge-multiple: true
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
-        with:
-          fail_ci_if_error: true
-          flags: python
-          use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
-
-  python-coverage-upload-individual:
-    if: ${{ inputs.run-tests-individually }}
-    name: 📈
-    needs: [python-tests-individual]
     runs-on: ubuntu-latest
     permissions:
       contents: read # Required for the `actions/checkout` action

--- a/.github/workflows/reusable-python-ci.yml
+++ b/.github/workflows/reusable-python-ci.yml
@@ -63,7 +63,17 @@ jobs:
       fail-fast: false
       matrix:
         runs-on:
-          [ubuntu-24.04, ubuntu-24.04-arm, macos-13, macos-14, windows-latest]
+          [
+            ubuntu-22.04,
+            ubuntu-22.04-arm,
+            ubuntu-24.04,
+            ubuntu-24.04-arm,
+            macos-13,
+            macos-14,
+            macos-15,
+            windows-2022,
+            windows-2025,
+          ]
     uses: ./.github/workflows/reusable-python-tests.yml
     with:
       runs-on: ${{ matrix.runs-on }}
@@ -78,7 +88,17 @@ jobs:
       fail-fast: false
       matrix:
         runs-on:
-          [ubuntu-24.04, ubuntu-24.04-arm, macos-13, macos-14, windows-latest]
+          [
+            ubuntu-22.04,
+            ubuntu-22.04-arm,
+            ubuntu-24.04,
+            ubuntu-24.04-arm,
+            macos-13,
+            macos-14,
+            macos-15,
+            windows-2022,
+            windows-2025,
+          ]
         python-version: ${{ fromJson(needs.dist.outputs.python-versions) }}
         session: ["minimums", "tests"]
     uses: ./.github/workflows/reusable-python-tests-individual.yml

--- a/.github/workflows/reusable-python-ci.yml
+++ b/.github/workflows/reusable-python-ci.yml
@@ -67,7 +67,7 @@ on:
         type: boolean
 
 jobs:
-  build-matrices:
+  build-matrix:
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.build-matrix.outputs.matrix }}
@@ -107,7 +107,7 @@ jobs:
           echo $(echo $matrix | jq -rc .)
 
   python-tests:
-    needs: [build-matrices]
+    needs: [build-matrix]
     name: 🐍 ${{ matrix.runs-on }}
     strategy:
       fail-fast: false

--- a/.github/workflows/reusable-python-tests-individual.yml
+++ b/.github/workflows/reusable-python-tests-individual.yml
@@ -10,10 +10,6 @@ on:
         description: "The Python version to use"
         required: true
         type: string
-      session:
-        description: "The nox session to run (typically 'tests' or 'minimums')"
-        required: true
-        type: string
       setup-z3:
         description: "Whether to set up Z3"
         default: false
@@ -25,7 +21,7 @@ on:
 
 jobs:
   python-tests:
-    name: 🐍 ${{ inputs.session }} ${{ inputs.python-version }} ${{ inputs.runs-on }}
+    name: 🐍 ${{ inputs.python-version }} ${{ inputs.runs-on }}
     runs-on: ${{ inputs.runs-on }}
     env:
       FORCE_COLOR: 3
@@ -50,19 +46,22 @@ jobs:
         with:
           prepend_symlinks_to_path: false
           windows_compile_environment: msvc
-          override_cache_key: python-tests-${{ inputs.runs-on }}-${{ inputs.python-version }}-${{ inputs.session }}
+          override_cache_key: python-tests-${{ inputs.runs-on }}-${{ inputs.python-version }}
       # set up mold as linker for faster C++ builds (Linux only)
       - name: Set up mold as linker (Linux only)
         uses: rui314/setup-mold@v1
       # set up uv for faster Python package management
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@v5
-      # run the nox session (assumes a corresponding nox session exists) with coverage
-      - name: Test on 🐍 ${{ inputs.python-version }}
-        run: uvx nox -s ${{ inputs.session }}-${{ inputs.python-version }} --verbose -- --cov --cov-report=xml:coverage-${{ inputs.session }}-${{ inputs.python-version }}-${{ inputs.runs-on }}.xml
+      # run the nox minimums session (assumes a nox session named "minimums" exists) with coverage
+      - name: 🐍 Test with minimal versions
+        run: uvx nox -s minimums-${{ inputs.python-version }} --verbose -- --cov --cov-report=xml:coverage-${{ inputs.python-version }}-${{ inputs.runs-on }}.xml --cov-append
+      # run the nox tests session (assumes a nox session named "tests" exists) with coverage
+      - name: 🐍 Test
+        run: uvx nox -s tests-${{ inputs.python-version }} --verbose -- --cov --cov-report=xml:coverage-${{ inputs.python-version }}-${{ inputs.runs-on }}.xml --cov-append
       # upload the report as an artifact to GitHub so that it can later be uploaded to Codecov
-      - name: Upload 🐍 coverage report for the ${{ inputs.session }} session on 🐍 ${{ inputs.python-version }} running ${{ inputs.runs-on }}
+      - name: Upload 🐍 coverage report for 🐍 ${{ inputs.python-version }} running ${{ inputs.runs-on }}
         uses: actions/upload-artifact@v4
         with:
-          name: coverage-${{ inputs.session }}-${{ inputs.python-version }}-${{ inputs.runs-on }}
+          name: coverage-${{ inputs.python-version }}-${{ inputs.runs-on }}
           path: coverage-*

--- a/.github/workflows/reusable-python-tests.yml
+++ b/.github/workflows/reusable-python-tests.yml
@@ -49,14 +49,12 @@ jobs:
       # set up uv for faster Python package management
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@v5
-      # set up nox for convenient testing
-      - uses: wntrblm/nox@2024.10.09
       # run the nox minimums session (assumes a nox session named "minimums" exists) with coverage
       - name: 🐍 Test with minimal versions
-        run: nox -s minimums --verbose -- --cov --cov-report=xml:coverage-${{ inputs.runs-on }}.xml --cov-append
+        run: uvx nox -s minimums --verbose -- --cov --cov-report=xml:coverage-${{ inputs.runs-on }}.xml --cov-append
       # run the nox tests session (assumes a nox session named "tests" exists) with coverage
       - name: 🐍 Test
-        run: nox -s tests --verbose -- --cov --cov-report=xml:coverage-${{ inputs.runs-on }}.xml --cov-append
+        run: uvx nox -s tests --verbose -- --cov --cov-report=xml:coverage-${{ inputs.runs-on }}.xml --cov-append
       # upload the report as an artifact to GitHub so that it can later be uploaded to Codecov
       - name: Upload 🐍 coverage report for ${{ inputs.runs-on }}
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
This PR experiments with broadening the type of runners that we run CI on. 
In particular, it allows one to dynamically configure the workflow runs that should be enabled.
As a result, projects can decide on their own under which constellations they want to test.

On the C++ side, the currently available workflows are:
- (ubuntu-24.04, ubuntu-22.04, ubuntu-24.04-arm, ubuntu-22.04-arm) x (gcc, clang) x (Release, Debug)
- (macos-13, macos-14, macos-15) x (clang, gcc) x (Release, Debug)
- (windows-2022, windows-2025) x (msvc, clang) x (Release, Debug)

with the following combinations being turned on by default:
- ubuntu-24.04, gcc, Release,
- ubuntu-22.04, gcc, Release,
- ubuntu-24.04-arm, gcc, Release,
- ubuntu-22.04-arm, gcc, Release,
- macos-13, clang, Release,
- macos-14, clang, Release,
- windows-2022, msvc, Release,

On the Python side, the available workflows are
- 🐧 ubuntu-22.04,
- 🐧 ubuntu-22.04-arm,
- 🐧 ubuntu-24.04,
- 🐧 ubuntu-24.04-arm,
- 🍎 macos-13,
- 🍎 macos-14,
- 🍎 macos-15,
- 🏁 windows-2022,
- 🏁 windows-2025,

with the following runs being turned on by default:
- 🐧 ubuntu-24.04,
- 🐧 ubuntu-24.04-arm,
- 🍎 macos-13,
- 🍎 macos-14,
- 🏁 windows-2022,

A first prototype how to use this new functionality is being explored in https://github.com/cda-tum/mqt-core/pull/803, where an `extensive-cpp-ci` and an `extensive-python-ci` option are added to conditionally run more-than-default testing on demand.

---
Old Description: Due to the amount of runs that this creates, I am rather hesitant to directly merge this. Hence, I will keep this open for now and keep the branch itself. This way, we can test the real-world consequences of this and decide then.