### PR TITLE
⬆️ update default Z3 version to `4.13.4`

### DIFF
--- a/.github/workflows/reusable-code-ql-cpp.yml
+++ b/.github/workflows/reusable-code-ql-cpp.yml
@@ -12,7 +12,7 @@ on:
         type: boolean
       z3-version:
         description: "The version of Z3 to set up"
-        default: "4.13.0"
+        default: "4.13.4"
         type: string
 
 jobs:

--- a/.github/workflows/reusable-code-ql.yml
+++ b/.github/workflows/reusable-code-ql.yml
@@ -13,7 +13,7 @@ on:
         type: boolean
       z3-version:
         description: "The version of Z3 to set up"
-        default: "4.13.0"
+        default: "4.13.4"
         type: string
       enable-cpp:
         description: "Whether to enable C++ analysis"

--- a/.github/workflows/reusable-cpp-ci.yml
+++ b/.github/workflows/reusable-cpp-ci.yml
@@ -15,7 +15,7 @@ on:
         type: boolean
       z3-version:
         description: "The version of Z3 to set up"
-        default: "4.13.0"
+        default: "4.13.4"
         type: string
       ###---- Ubuntu-specific inputs --------------------------------------------------------------------------------###
       ### Runs (ubuntu-24.04, ubuntu-22.04, ubuntu-24.04-arm, ubuntu-22.04-arm) x (gcc, clang) x (Release, Debug)

--- a/.github/workflows/reusable-cpp-coverage.yml
+++ b/.github/workflows/reusable-cpp-coverage.yml
@@ -12,7 +12,7 @@ on:
         type: boolean
       z3-version:
         description: "The version of Z3 to set up"
-        default: "4.13.0"
+        default: "4.13.4"
         type: string
 
 jobs:

--- a/.github/workflows/reusable-cpp-linter.yml
+++ b/.github/workflows/reusable-cpp-linter.yml
@@ -24,7 +24,7 @@ on:
         type: boolean
       z3-version:
         description: "The version of Z3 to set up"
-        default: "4.13.0"
+        default: "4.13.4"
         type: string
 
 jobs:

--- a/.github/workflows/reusable-python-ci.yml
+++ b/.github/workflows/reusable-python-ci.yml
@@ -10,7 +10,7 @@ on:
         type: boolean
       z3-version:
         description: "The version of Z3 to set up"
-        default: "4.13.0"
+        default: "4.13.4"
         type: string
       ###---- Ubuntu-specific inputs --------------------------------------------------------------------------------###
       ### Runs (ubuntu-24.04, ubuntu-22.04, ubuntu-24.04-arm, ubuntu-22.04-arm)

--- a/.github/workflows/reusable-python-linter.yml
+++ b/.github/workflows/reusable-python-linter.yml
@@ -8,7 +8,7 @@ on:
         type: boolean
       z3-version:
         description: "The version of Z3 to set up"
-        default: "4.13.0"
+        default: "4.13.4"
         type: string
 
 jobs:

--- a/.github/workflows/reusable-python-packaging.yml
+++ b/.github/workflows/reusable-python-packaging.yml
@@ -13,7 +13,7 @@ on:
         type: boolean
       z3-version:
         description: "The version of Z3 to set up"
-        default: "4.13.0"
+        default: "4.13.4"
         type: string
       build-emulated-wheels:
         description: "Whether to build wheels for platforms that require emulation"

--- a/.github/workflows/reusable-python-tests-individual.yml
+++ b/.github/workflows/reusable-python-tests-individual.yml
@@ -16,7 +16,7 @@ on:
         type: boolean
       z3-version:
         description: "The version of Z3 to set up"
-        default: "4.13.0"
+        default: "4.13.4"
         type: string
 
 jobs:

--- a/.github/workflows/reusable-python-tests.yml
+++ b/.github/workflows/reusable-python-tests.yml
@@ -12,7 +12,7 @@ on:
         type: boolean
       z3-version:
         description: "The version of Z3 to set up"
-        default: "4.13.0"
+        default: "4.13.4"
         type: string
 
 jobs:


### PR DESCRIPTION
This PR updates the default Z3 version used in the workflows to the latest release of Z3, which is `v4.13.4`.