### PR TITLE
🔥 remove emulated wheel builds

### DIFF
--- a/.github/workflows/reusable-python-packaging.yml
+++ b/.github/workflows/reusable-python-packaging.yml
@@ -15,10 +15,6 @@ on:
         description: "The version of Z3 to set up"
         default: "4.13.4"
         type: string
-      build-emulated-wheels:
-        description: "Whether to build wheels for platforms that require emulation"
-        default: true
-        type: boolean
 
 jobs:
   build_sdist:
@@ -123,43 +119,3 @@ jobs:
         with:
           name: ${{ github.event_name == 'pull_request' && 'dev-' || '' }}cibw-wheels-${{ matrix.runs-on }}-${{ strategy.job-index }}
           path: wheelhouse/*.whl
-
-  build_wheels_emulation:
-    if: ${{ !inputs.pure-python && inputs.build-emulated-wheels }}
-    name: 🎡 ${{ matrix.arch }}
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        # build wheels for all supported Python versions on all platforms that require emulation
-        arch: ["s390x", "ppc64le"]
-    steps:
-      # check out the repository (including submodules and all history)
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          submodules: recursive
-      # set up QEMU
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-      # optionally set up Z3
-      - if: ${{ inputs.setup-z3 }}
-        name: Set environment variables for Z3 installation in manylinux image
-        run: |
-          echo "CIBW_BEFORE_ALL_LINUX=/opt/python/cp311-cp311/bin/pip install z3-solver==${{ inputs.z3-version }}" >> $GITHUB_ENV
-      # set up uv for faster Python package management
-      - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@v5
-        with:
-          enable-cache: false
-      # run cibuildwheel to build wheels for the specified Python version
-      - name: Build wheels
-        uses: pypa/cibuildwheel@v2.22
-        env:
-          CIBW_ARCHS_LINUX: ${{ matrix.arch }}
-          CIBW_TEST_SKIP: "cp*"
-      # upload the wheels as an artifact (adds a `dev-` prefix for PRs)
-      - uses: actions/upload-artifact@v4
-        with:
-          name: ${{ github.event_name == 'pull_request' && 'dev-' || '' }}cibw-wheels-${{ matrix.arch }}-${{ strategy.job-index }}
-          path: ./wheelhouse/*.whl


### PR DESCRIPTION
This PR drops support for building emulated wheels.
With the new GitHub Ubuntu ARM runners, the only two platforms left to build under isolation are very exotic.
Emulation builds are very demanding on CI. So we might as well drop them entirely.