### PR TITLE
🔥 do not force `CIBW_BEFORE_ALL` for Z3 setup on manylinux

### DIFF
--- a/.github/workflows/reusable-python-packaging.yml
+++ b/.github/workflows/reusable-python-packaging.yml
@@ -90,11 +90,6 @@ jobs:
         uses: cda-tum/setup-z3@v1
         with:
           version: ${{ inputs.z3-version }}
-      # optionally set up Z3 (Ubuntu only)
-      - if: ${{ inputs.setup-z3 && (matrix.runs-on == 'ubuntu-24.04' || matrix.runs-on == 'ubuntu-24.04-arm') }}
-        name: Set environment variables for Z3 installation in manylinux image
-        run: |
-          echo "CIBW_BEFORE_ALL_LINUX=/opt/python/cp311-cp311/bin/pip install z3-solver==${{ inputs.z3-version }}" >> $GITHUB_ENV
       # set up ccache for faster C++ builds
       - if: ${{ matrix.runs-on != 'ubuntu-24.04' && matrix.runs-on != 'ubuntu-24.04-arm' }}
         name: Setup ccache


### PR DESCRIPTION
Projects can set this on their own in their `pyproject.toml`. See https://github.com/cda-tum/mqt-qmap for an example.