### PR TITLE
🩹 Fix typo in CI config swapping `gcc` and `clang` on Ubuntu

### DIFF
--- a/.github/workflows/reusable-cpp-tests-ubuntu.yml
+++ b/.github/workflows/reusable-cpp-tests-ubuntu.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Configure CMake
         run: |
           cmake_args="${{ inputs.cmake-args }}"
-          if [ "${{ inputs.compiler }}" == "gcc" ]; then
+          if [ "${{ inputs.compiler }}" == "clang" ]; then
             cmake_args="$cmake_args -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++"
           fi
           cmake -G Ninja -S . -B build -DCMAKE_BUILD_TYPE=${{ inputs.config }} $cmake_args


### PR DESCRIPTION
This pull request resolves a typo in the Ubuntu C++ CI configuration, which incorrectly swapped `gcc` and `clang` configurations. This fix ensures the proper setup for respective compilers during CI runs.