### PR TITLE
🚨 optionally build the project as part of the cpp-linter workflow

### DIFF
--- a/.github/workflows/reusable-cpp-linter.yml
+++ b/.github/workflows/reusable-cpp-linter.yml
@@ -18,6 +18,10 @@ on:
         description: "Extra arguments to pass to the cpp-linter"
         default: "-std=c++17"
         type: string
+      build-project:
+        description: "Whether to build the project"
+        default: false
+        type: boolean
       setup-z3:
         description: "Whether to set up Z3"
         default: false
@@ -65,6 +69,17 @@ jobs:
           echo "CXX=clang++-${{ env.clang-version }}" >> $GITHUB_ENV
           echo "MLIR_DIR=/usr/lib/llvm-${{ env.clang-version }}/lib/cmake/mlir" >> $GITHUB_ENV
           echo "LLVM_DIR=/usr/lib/llvm-${{ env.clang-version }}/lib/cmake/llvm" >> $GITHUB_ENV
+      # set up ccache for faster C++ builds if building the project
+      - if: ${{ inputs.build-project }}
+        name: Setup ccache
+        uses: Chocobo1/setup-ccache-action@v1
+        with:
+          prepend_symlinks_to_path: false
+          override_cache_key: c++-lint
+      # set up mold as linker for faster C++ builds
+      - if: ${{ inputs.build-project }}
+        name: Set up mold as linker
+        uses: rui314/setup-mold@v1
       # generate a compilation database (assumes that the CMake project has `CMAKE_EXPORT_COMPILE_COMMANDS` set)
       - name: Generate compilation database
         run: |
@@ -75,6 +90,10 @@ jobs:
           echo $MLIR_DIR
           echo $LLVM_DIR
           cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug ${{ inputs.cmake-args }}
+      # build the project, if configured to do so
+      - if: ${{ inputs.build-project }}
+        name: Build
+        run: cmake --build build --config Debug
       # runs the cpp-linter action using the generated compilation database and the specified clang version
       - name: Run cpp-linter
         uses: cpp-linter/cpp-linter-action@v2


### PR DESCRIPTION
This can be helpful for MLIR-based projects where some files are only generated at build time.