### PR TITLE
🔧 Update ignore patterns in C++ linter workflow to include 'include' directory

### DIFF
--- a/.github/workflows/reusable-cpp-linter.yml
+++ b/.github/workflows/reusable-cpp-linter.yml
@@ -104,7 +104,7 @@ jobs:
           style: ""
           tidy-checks: ""
           version: ${{ env.clang-version }}
-          ignore: "build|!build/mlir/**|**/python|**/include"
+          ignore: "build|!build/mlir/**|**/python|**/include|include"
           thread-comments: ${{ github.event_name == 'pull_request' && 'update' }}
           step-summary: true
           database: "build"


### PR DESCRIPTION
### Description

This pull request refines the ignore patterns in the C++ linter workflow to exclude the `include` directory from linting checks.

Thanks @TooMuchDakka for the tip.