### PR TITLE
 🚸 Adapt C++ workflows to require CMake presets

### DIFF
--- a/.github/workflows/reusable-cpp-coverage.yml
+++ b/.github/workflows/reusable-cpp-coverage.yml
@@ -10,10 +10,6 @@ name: 🇨 • Coverage
 on:
   workflow_call:
     inputs:
-      cmake-args:
-        description: "Additional arguments to pass to CMake"
-        default: "-G Ninja"
-        type: string
       setup-z3:
         description: "Whether to set up Z3"
         default: false
@@ -30,10 +26,6 @@ on:
         description: "The LLVM version to set up (formatted as 'major.minor.patch') or commit hash (minimum 7 characters, e.g., 'a832a52')"
         default: "21.1.8"
         type: string
-      use-cmake-presets:
-        description: "Whether to use cmake-presets. Assumes that a 'coverage' preset is defined"
-        default: false
-        type: boolean
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}-cpp-coverage
@@ -99,35 +91,12 @@ jobs:
           echo "LIT_BIN=$(which lit)" >> $GITHUB_ENV
 
       - name: Configure CMake
-        if: ${{ !inputs.use-cmake-presets }}
-        env:
-          CMAKE_ARGS: ${{ inputs.cmake-args }}
-          SETUP_MLIR: ${{ inputs.setup-mlir }}
-        run: |
-          LIT_ARG=""
-          if [ "$SETUP_MLIR" = "true" ]; then
-            LIT_ARG="-DLLVM_EXTERNAL_LIT=$(which lit)"
-          fi
-          cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DENABLE_COVERAGE=ON $CMAKE_ARGS "$LIT_ARG"
-
-      - name: Configure CMake with cmake-presets
-        if: ${{ inputs.use-cmake-presets }}
         run: cmake --preset coverage
 
       - name: Build
-        if: ${{ !inputs.use-cmake-presets }}
-        run: cmake --build build --config Debug
-
-      - name: Build with cmake-presets
-        if: ${{ inputs.use-cmake-presets }}
         run: cmake --build --preset coverage
 
       - name: Test
-        if: ${{ !inputs.use-cmake-presets }}
-        run: ctest -C Debug --output-on-failure --test-dir build --repeat until-pass:3 --timeout 600
-
-      - name: Test with cmake-presets
-        if: ${{ inputs.use-cmake-presets }}
         run: ctest --preset coverage
 
       - name: Upload coverage to Codecov

--- a/.github/workflows/reusable-cpp-coverage.yml
+++ b/.github/workflows/reusable-cpp-coverage.yml
@@ -30,6 +30,14 @@ on:
         description: "The LLVM version to set up (formatted as 'major.minor.patch') or commit hash (minimum 7 characters, e.g., 'a832a52')"
         default: "21.1.8"
         type: string
+      use-cmake-presets:
+        description: "Whether to use CMake presets for configuration and build."
+        default: false
+        type: boolean
+      preset-name:
+        description: "The CMake preset to use for configuration and build."
+        default: ""
+        type: string
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}-cpp-coverage
@@ -93,6 +101,7 @@ jobs:
         run: uv pip install lit
 
       - name: Configure CMake
+        if: ${{ !inputs.use-cmake-presets }}
         env:
           CMAKE_ARGS: ${{ inputs.cmake-args }}
           SETUP_MLIR: ${{ inputs.setup-mlir }}
@@ -103,8 +112,27 @@ jobs:
           fi
           cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DENABLE_COVERAGE=ON $CMAKE_ARGS "$LIT_ARG"
 
+      - name: Configure CMake with cmake-presets
+        if: ${{ inputs.use-cmake-presets }}
+        env:
+          PRESET_NAME: ${{ inputs.preset-name }}
+          SETUP_MLIR: ${{ inputs.setup-mlir }}
+        run: |
+          LIT_ARG=""
+            if [ "$SETUP_MLIR" = "true" ]; then
+              LIT_ARG="-DLLVM_EXTERNAL_LIT=$(which lit)"
+            fi
+          cmake --preset "$PRESET_NAME" -DENABLE_COVERAGE=ON "$LIT_ARG"
+
       - name: Build
+        if: ${{ !inputs.use-cmake-presets }}
         run: cmake --build build --config Debug
+
+      - name: Build with cmake-presets
+        if: ${{ inputs.use-cmake-presets }}
+        env:
+          PRESET_NAME: ${{ inputs.preset-name }}
+        run: cmake --build --preset "$PRESET_NAME"
 
       - name: Test
         run: ctest -C Debug --output-on-failure --test-dir build --repeat until-pass:3 --timeout 600

--- a/.github/workflows/reusable-cpp-coverage.yml
+++ b/.github/workflows/reusable-cpp-coverage.yml
@@ -94,7 +94,9 @@ jobs:
 
       - name: Install lit
         if: ${{ inputs.setup-mlir }}
-        run: uv pip install lit
+        run: |
+          uv pip install lit
+          echo "LIT_BIN=$(which lit)" >> $GITHUB_ENV
 
       - name: Configure CMake
         if: ${{ !inputs.use-cmake-presets }}
@@ -110,14 +112,7 @@ jobs:
 
       - name: Configure CMake with cmake-presets
         if: ${{ inputs.use-cmake-presets }}
-        env:
-          SETUP_MLIR: ${{ inputs.setup-mlir }}
-        run: |
-          LIT_ARG=""
-            if [ "$SETUP_MLIR" = "true" ]; then
-              LIT_ARG="-DLLVM_EXTERNAL_LIT=$(which lit)"
-            fi
-          cmake --preset coverage "$LIT_ARG"
+        run: cmake --preset coverage
 
       - name: Build
         if: ${{ !inputs.use-cmake-presets }}

--- a/.github/workflows/reusable-cpp-coverage.yml
+++ b/.github/workflows/reusable-cpp-coverage.yml
@@ -135,7 +135,14 @@ jobs:
         run: cmake --build --preset "$PRESET_NAME"
 
       - name: Test
+        if: ${{ !inputs.use-cmake-presets }}
         run: ctest -C Debug --output-on-failure --test-dir build --repeat until-pass:3 --timeout 600
+
+      - name: Test with cmake-presets
+        if: ${{ inputs.use-cmake-presets }}
+        env:
+          PRESET_NAME: ${{ inputs.preset-name }}
+        run: ctest --preset "$PRESET_NAME"
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0

--- a/.github/workflows/reusable-cpp-coverage.yml
+++ b/.github/workflows/reusable-cpp-coverage.yml
@@ -31,13 +31,9 @@ on:
         default: "21.1.8"
         type: string
       use-cmake-presets:
-        description: "Whether to use CMake presets for configuration and build."
+        description: "Whether to use cmake-presets. Assumes that a 'coverage' preset is defined"
         default: false
         type: boolean
-      preset-name:
-        description: "The CMake preset to use for configuration and build."
-        default: ""
-        type: string
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}-cpp-coverage
@@ -115,14 +111,13 @@ jobs:
       - name: Configure CMake with cmake-presets
         if: ${{ inputs.use-cmake-presets }}
         env:
-          PRESET_NAME: ${{ inputs.preset-name }}
           SETUP_MLIR: ${{ inputs.setup-mlir }}
         run: |
           LIT_ARG=""
             if [ "$SETUP_MLIR" = "true" ]; then
               LIT_ARG="-DLLVM_EXTERNAL_LIT=$(which lit)"
             fi
-          cmake --preset "$PRESET_NAME" -DENABLE_COVERAGE=ON "$LIT_ARG"
+          cmake --preset coverage "$LIT_ARG"
 
       - name: Build
         if: ${{ !inputs.use-cmake-presets }}
@@ -130,9 +125,7 @@ jobs:
 
       - name: Build with cmake-presets
         if: ${{ inputs.use-cmake-presets }}
-        env:
-          PRESET_NAME: ${{ inputs.preset-name }}
-        run: cmake --build --preset "$PRESET_NAME"
+        run: cmake --build --preset coverage
 
       - name: Test
         if: ${{ !inputs.use-cmake-presets }}
@@ -140,9 +133,7 @@ jobs:
 
       - name: Test with cmake-presets
         if: ${{ inputs.use-cmake-presets }}
-        env:
-          PRESET_NAME: ${{ inputs.preset-name }}
-        run: ctest --preset "$PRESET_NAME"
+        run: ctest --preset coverage
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0

--- a/.github/workflows/reusable-cpp-linter.yml
+++ b/.github/workflows/reusable-cpp-linter.yml
@@ -158,6 +158,7 @@ jobs:
         run: cmake --preset lint
 
       - name: Build
+        if: ${{ inputs.build-project }}
         run: cmake --build --preset lint
 
       # runs the cpp-linter action using the generated compilation database and the specified clang version

--- a/.github/workflows/reusable-cpp-linter.yml
+++ b/.github/workflows/reusable-cpp-linter.yml
@@ -18,10 +18,6 @@ on:
         description: "Whether to only lint files that have changed"
         default: true
         type: boolean
-      cmake-args:
-        description: "Additional arguments to pass to CMake"
-        default: ""
-        type: string
       cpp-linter-extra-args:
         description: "Extra arguments to pass to the cpp-linter"
         default: "-std=c++17"
@@ -58,10 +54,6 @@ on:
         description: "The LLVM version to set up (formatted as 'major.minor.patch') or commit hash (minimum 7 characters like 'a832a52')"
         default: "21.1.8"
         type: string
-      use-cmake-presets:
-        description: "Whether to use cmake-presets. Assumes that a 'lint' preset is defined"
-        default: false
-        type: boolean
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}-cpp-linter
@@ -162,30 +154,10 @@ jobs:
             uv pip install "${pkgs_array[@]}"
           fi
 
-      # generate a compilation database (assumes that the CMake project has `CMAKE_EXPORT_COMPILE_COMMANDS` set)
       - name: Generate compilation database
-        if: ${{ !inputs.use-cmake-presets }}
-        env:
-          CMAKE_ARGS: ${{ inputs.cmake-args }}
-        run: |
-          echo $CC
-          echo $CXX
-          $CC --version
-          $CXX --version
-          echo $MLIR_DIR
-          echo $LLVM_DIR
-          cmake -G Ninja -S . -B build -DCMAKE_BUILD_TYPE=Debug $CMAKE_ARGS
-
-      - name: Generate compilation database with cmake-presets
-        if: ${{ inputs.use-cmake-presets }}
         run: cmake --preset lint
 
       - name: Build
-        if: ${{ inputs.build-project && !inputs.use-cmake-presets }}
-        run: cmake --build build --config Debug
-
-      - name: Build with cmake-presets
-        if: ${{ inputs.build-project && inputs.use-cmake-presets }}
         run: cmake --build --preset lint
 
       # runs the cpp-linter action using the generated compilation database and the specified clang version

--- a/.github/workflows/reusable-cpp-linter.yml
+++ b/.github/workflows/reusable-cpp-linter.yml
@@ -59,13 +59,9 @@ on:
         default: "21.1.8"
         type: string
       use-cmake-presets:
-        description: "Whether to use CMake presets for configuration and build."
+        description: "Whether to use cmake-presets. Assumes that a 'lint' preset is defined"
         default: false
         type: boolean
-      preset-name:
-        description: "The CMake preset to use for configuration and build."
-        default: ""
-        type: string
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}-cpp-linter
@@ -182,9 +178,7 @@ jobs:
 
       - name: Generate compilation database with cmake-presets
         if: ${{ inputs.use-cmake-presets }}
-        env:
-          PRESET_NAME: ${{ inputs.preset-name }}
-        run: cmake --preset "$PRESET_NAME"
+        run: cmake --preset lint
 
       - name: Build
         if: ${{ inputs.build-project && !inputs.use-cmake-presets }}
@@ -192,9 +186,7 @@ jobs:
 
       - name: Build with cmake-presets
         if: ${{ inputs.build-project && inputs.use-cmake-presets }}
-        env:
-          PRESET_NAME: ${{ inputs.preset-name }}
-        run: cmake --build --preset "$PRESET_NAME"
+        run: cmake --build --preset lint
 
       # runs the cpp-linter action using the generated compilation database and the specified clang version
       - name: Run cpp-linter

--- a/.github/workflows/reusable-cpp-linter.yml
+++ b/.github/workflows/reusable-cpp-linter.yml
@@ -58,6 +58,14 @@ on:
         description: "The LLVM version to set up (formatted as 'major.minor.patch') or commit hash (minimum 7 characters like 'a832a52')"
         default: "21.1.8"
         type: string
+      use-cmake-presets:
+        description: "Whether to use CMake presets for configuration and build."
+        default: false
+        type: boolean
+      preset-name:
+        description: "The CMake preset to use for configuration and build."
+        default: ""
+        type: string
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}-cpp-linter
@@ -160,6 +168,7 @@ jobs:
 
       # generate a compilation database (assumes that the CMake project has `CMAKE_EXPORT_COMPILE_COMMANDS` set)
       - name: Generate compilation database
+        if: ${{ !inputs.use-cmake-presets }}
         env:
           CMAKE_ARGS: ${{ inputs.cmake-args }}
         run: |
@@ -171,9 +180,21 @@ jobs:
           echo $LLVM_DIR
           cmake -G Ninja -S . -B build -DCMAKE_BUILD_TYPE=Debug $CMAKE_ARGS
 
+      - name: Generate compilation database with cmake-presets
+        if: ${{ inputs.use-cmake-presets }}
+        env:
+          PRESET_NAME: ${{ inputs.preset-name }}
+        run: cmake --preset "$PRESET_NAME"
+
       - name: Build
-        if: ${{ inputs.build-project }}
+        if: ${{ inputs.build-project && !inputs.use-cmake-presets }}
         run: cmake --build build --config Debug
+
+      - name: Build with cmake-presets
+        if: ${{ inputs.build-project && inputs.use-cmake-presets }}
+        env:
+          PRESET_NAME: ${{ inputs.preset-name }}
+        run: cmake --build --preset "$PRESET_NAME"
 
       # runs the cpp-linter action using the generated compilation database and the specified clang version
       - name: Run cpp-linter

--- a/.github/workflows/reusable-cpp-tests-macos.yml
+++ b/.github/workflows/reusable-cpp-tests-macos.yml
@@ -185,6 +185,13 @@ jobs:
         run: cmake --build --preset "$PRESET_NAME"
 
       - name: Test
+        if: ${{ !inputs.use-cmake-presets }}
         env:
           CONFIG: ${{ inputs.config }}
         run: ctest -C $CONFIG --output-on-failure --test-dir build --repeat until-pass:3 --timeout 600
+
+      - name: Test with cmake-presets
+        if: ${{ inputs.use-cmake-presets }}
+        env:
+          PRESET_NAME: ${{ inputs.preset-name }}
+        run: ctest --preset "$PRESET_NAME"

--- a/.github/workflows/reusable-cpp-tests-macos.yml
+++ b/.github/workflows/reusable-cpp-tests-macos.yml
@@ -54,7 +54,7 @@ on:
         default: "21.1.8"
         type: string
       use-cmake-presets:
-        description: "Whether to use CMake presets for configuration and build."
+        description: "Whether to use cmake-presets"
         default: false
         type: boolean
       preset-name:

--- a/.github/workflows/reusable-cpp-tests-macos.yml
+++ b/.github/workflows/reusable-cpp-tests-macos.yml
@@ -108,7 +108,9 @@ jobs:
 
       - name: Install lit
         if: ${{ inputs.setup-mlir }}
-        run: uv pip install lit
+        run: |
+          uv pip install lit
+          echo "LIT_BIN=$(which lit)" >> $GITHUB_ENV
 
       - name: Set up GCC
         if: ${{ startsWith(inputs.compiler, 'gcc-') }}
@@ -164,13 +166,7 @@ jobs:
         if: ${{ inputs.use-cmake-presets }}
         env:
           PRESET_NAME: ${{ inputs.preset-name }}
-          SETUP_MLIR: ${{ inputs.setup-mlir }}
-        run: |
-          LIT_ARG=""
-          if [ "$SETUP_MLIR" = "true" ]; then
-            LIT_ARG="-DLLVM_EXTERNAL_LIT=$(which lit)"
-          fi
-          cmake --preset "$PRESET_NAME" "$LIT_ARG"
+        run: cmake --preset "$PRESET_NAME"
 
       - name: Build
         if: ${{ !inputs.use-cmake-presets }}

--- a/.github/workflows/reusable-cpp-tests-macos.yml
+++ b/.github/workflows/reusable-cpp-tests-macos.yml
@@ -43,7 +43,7 @@ on:
         type: string
       preset-name:
         description: "The CMake preset to use for configuration and build."
-        default: ""
+        required: true
         type: string
 
 concurrency:

--- a/.github/workflows/reusable-cpp-tests-macos.yml
+++ b/.github/workflows/reusable-cpp-tests-macos.yml
@@ -42,7 +42,7 @@ on:
         default: "21.1.8"
         type: string
       preset-name:
-        description: "The CMake preset to use for configuration and build."
+        description: "The CMake preset to use for configuration and build"
         required: true
         type: string
 

--- a/.github/workflows/reusable-cpp-tests-macos.yml
+++ b/.github/workflows/reusable-cpp-tests-macos.yml
@@ -53,6 +53,14 @@ on:
         description: "The LLVM version to set up (formatted as 'major.minor.patch') or commit hash (minimum 7 characters, e.g., 'a832a52')"
         default: "21.1.8"
         type: string
+      use-cmake-presets:
+        description: "Whether to use CMake presets for configuration and build."
+        default: false
+        type: boolean
+      preset-name:
+        description: "The CMake preset to use for configuration and build."
+        default: ""
+        type: string
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}-cpp-tests-${{ inputs.runs-on }}-${{ inputs.compiler }}-${{ inputs.config }}
@@ -140,6 +148,7 @@ jobs:
           fi
 
       - name: Configure CMake
+        if: ${{ !inputs.use-cmake-presets }}
         env:
           CONFIG: ${{ inputs.config }}
           CMAKE_ARGS: ${{ inputs.cmake-args }}
@@ -151,10 +160,29 @@ jobs:
           fi
           cmake -G Ninja -S . -B build -DCMAKE_BUILD_TYPE=$CONFIG $CMAKE_ARGS "$LIT_ARG"
 
+      - name: Configure CMake with cmake-presets
+        if: ${{ inputs.use-cmake-presets }}
+        env:
+          PRESET_NAME: ${{ inputs.preset-name }}
+          SETUP_MLIR: ${{ inputs.setup-mlir }}
+        run: |
+          LIT_ARG=""
+          if [ "$SETUP_MLIR" = "true" ]; then
+            LIT_ARG="-DLLVM_EXTERNAL_LIT=$(which lit)"
+          fi
+          cmake --preset "$PRESET_NAME" "$LIT_ARG"
+
       - name: Build
+        if: ${{ !inputs.use-cmake-presets }}
         env:
           CONFIG: ${{ inputs.config }}
         run: cmake --build build --config $CONFIG
+
+      - name: Build with cmake-presets
+        if: ${{ inputs.use-cmake-presets }}
+        env:
+          PRESET_NAME: ${{ inputs.preset-name }}
+        run: cmake --build --preset "$PRESET_NAME"
 
       - name: Test
         env:

--- a/.github/workflows/reusable-cpp-tests-macos.yml
+++ b/.github/workflows/reusable-cpp-tests-macos.yml
@@ -16,12 +16,6 @@ on:
           This can be any valid macOS runner image, such as 'macos-15', 'macos-26', or 'macos-26-intel'.
         default: "macos-latest"
         type: string
-      config:
-        description: >
-          The build type to use. Defaults to 'Release'.
-          This can be any valid CMake build type, such as 'Debug' or 'Release'.
-        default: "Release"
-        type: string
       compiler:
         description: >
           The compiler to use. Defaults to 'clang'.
@@ -30,12 +24,6 @@ on:
           If 'gcc-XX' is selected, this will use `gcc-XX` from Homebrew, where XX is the version number (e.g., 'gcc-14').
           A specific version of Clang can be requested via 'clang-XX', where XX is the version number (e.g., 'clang-20').
         default: "clang"
-        type: string
-      cmake-args:
-        description: >
-          Additional arguments to pass to CMake. Defaults to an empty string.
-          This can be any valid CMake argument, such as '-DBUILD_SHARED_LIBS=ON'.
-        default: ""
         type: string
       setup-z3:
         description: "Whether to set up Z3"
@@ -53,17 +41,13 @@ on:
         description: "The LLVM version to set up (formatted as 'major.minor.patch') or commit hash (minimum 7 characters, e.g., 'a832a52')"
         default: "21.1.8"
         type: string
-      use-cmake-presets:
-        description: "Whether to use cmake-presets"
-        default: false
-        type: boolean
       preset-name:
         description: "The CMake preset to use for configuration and build."
         default: ""
         type: string
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}-cpp-tests-${{ inputs.runs-on }}-${{ inputs.compiler }}-${{ inputs.use-cmake-presets && inputs.preset-name || inputs.config }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}-cpp-tests-${{ inputs.runs-on }}-${{ inputs.compiler }}-${{ inputs.preset-name }}
   cancel-in-progress: true
 
 permissions:
@@ -71,7 +55,7 @@ permissions:
 
 jobs:
   cpp-tests-macos:
-    name: 🍎 ${{ inputs.runs-on }} ${{ inputs.compiler }} ${{ inputs.use-cmake-presets && inputs.preset-name || inputs.config }}
+    name: 🍎 ${{ inputs.runs-on }} ${{ inputs.compiler }} ${{ inputs.preset-name }}
     runs-on: ${{ inputs.runs-on }}
     env:
       CMAKE_BUILD_PARALLEL_LEVEL: 4
@@ -150,44 +134,16 @@ jobs:
           fi
 
       - name: Configure CMake
-        if: ${{ !inputs.use-cmake-presets }}
-        env:
-          CONFIG: ${{ inputs.config }}
-          CMAKE_ARGS: ${{ inputs.cmake-args }}
-          SETUP_MLIR: ${{ inputs.setup-mlir }}
-        run: |
-          LIT_ARG=""
-          if [ "$SETUP_MLIR" = "true" ]; then
-            LIT_ARG="-DLLVM_EXTERNAL_LIT=$(which lit)"
-          fi
-          cmake -G Ninja -S . -B build -DCMAKE_BUILD_TYPE=$CONFIG $CMAKE_ARGS "$LIT_ARG"
-
-      - name: Configure CMake with cmake-presets
-        if: ${{ inputs.use-cmake-presets }}
         env:
           PRESET_NAME: ${{ inputs.preset-name }}
         run: cmake --preset "$PRESET_NAME"
 
       - name: Build
-        if: ${{ !inputs.use-cmake-presets }}
-        env:
-          CONFIG: ${{ inputs.config }}
-        run: cmake --build build --config $CONFIG
-
-      - name: Build with cmake-presets
-        if: ${{ inputs.use-cmake-presets }}
         env:
           PRESET_NAME: ${{ inputs.preset-name }}
         run: cmake --build --preset "$PRESET_NAME"
 
       - name: Test
-        if: ${{ !inputs.use-cmake-presets }}
-        env:
-          CONFIG: ${{ inputs.config }}
-        run: ctest -C $CONFIG --output-on-failure --test-dir build --repeat until-pass:3 --timeout 600
-
-      - name: Test with cmake-presets
-        if: ${{ inputs.use-cmake-presets }}
         env:
           PRESET_NAME: ${{ inputs.preset-name }}
         run: ctest --preset "$PRESET_NAME"

--- a/.github/workflows/reusable-cpp-tests-macos.yml
+++ b/.github/workflows/reusable-cpp-tests-macos.yml
@@ -63,7 +63,7 @@ on:
         type: string
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}-cpp-tests-${{ inputs.runs-on }}-${{ inputs.compiler }}-${{ inputs.config }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}-cpp-tests-${{ inputs.runs-on }}-${{ inputs.compiler }}-${{ inputs.use-cmake-presets && inputs.preset-name || inputs.config }}
   cancel-in-progress: true
 
 permissions:
@@ -71,7 +71,7 @@ permissions:
 
 jobs:
   cpp-tests-macos:
-    name: 🍎 ${{ inputs.runs-on }} ${{ inputs.compiler }} ${{ inputs.config }}
+    name: 🍎 ${{ inputs.runs-on }} ${{ inputs.compiler }} ${{ inputs.use-cmake-presets && inputs.preset-name || inputs.config }}
     runs-on: ${{ inputs.runs-on }}
     env:
       CMAKE_BUILD_PARALLEL_LEVEL: 4

--- a/.github/workflows/reusable-cpp-tests-ubuntu.yml
+++ b/.github/workflows/reusable-cpp-tests-ubuntu.yml
@@ -185,6 +185,13 @@ jobs:
         run: cmake --build --preset "$PRESET_NAME"
 
       - name: Test
+        if: ${{ !inputs.use-cmake-presets }}
         env:
           CONFIG: ${{ inputs.config }}
         run: ctest -C $CONFIG --output-on-failure --test-dir build --repeat until-pass:3 --timeout 600
+
+      - name: Test with cmake-presets
+        if: ${{ inputs.use-cmake-presets }}
+        env:
+          PRESET_NAME: ${{ inputs.preset-name }}
+        run: ctest --preset "$PRESET_NAME"

--- a/.github/workflows/reusable-cpp-tests-ubuntu.yml
+++ b/.github/workflows/reusable-cpp-tests-ubuntu.yml
@@ -54,7 +54,7 @@ on:
         default: "21.1.8"
         type: string
       use-cmake-presets:
-        description: "Whether to use CMake presets for configuration and build."
+        description: "Whether to use cmake-presets"
         default: false
         type: boolean
       preset-name:

--- a/.github/workflows/reusable-cpp-tests-ubuntu.yml
+++ b/.github/workflows/reusable-cpp-tests-ubuntu.yml
@@ -173,6 +173,7 @@ jobs:
           cmake --preset "$PRESET_NAME" "$LIT_ARG"
 
       - name: Build
+        if: ${{ !inputs.use-cmake-presets }}
         env:
           CONFIG: ${{ inputs.config }}
         run: cmake --build build --config $CONFIG

--- a/.github/workflows/reusable-cpp-tests-ubuntu.yml
+++ b/.github/workflows/reusable-cpp-tests-ubuntu.yml
@@ -43,7 +43,7 @@ on:
         type: string
       preset-name:
         description: "The CMake preset to use for configuration and build."
-        default: ""
+        required: true
         type: string
 
 concurrency:

--- a/.github/workflows/reusable-cpp-tests-ubuntu.yml
+++ b/.github/workflows/reusable-cpp-tests-ubuntu.yml
@@ -42,7 +42,7 @@ on:
         default: "21.1.8"
         type: string
       preset-name:
-        description: "The CMake preset to use for configuration and build."
+        description: "The CMake preset to use for configuration and build"
         required: true
         type: string
 

--- a/.github/workflows/reusable-cpp-tests-ubuntu.yml
+++ b/.github/workflows/reusable-cpp-tests-ubuntu.yml
@@ -63,7 +63,7 @@ on:
         type: string
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}-cpp-tests-${{ inputs.runs-on }}-${{ inputs.compiler }}-${{ inputs.config }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}-cpp-tests-${{ inputs.runs-on }}-${{ inputs.compiler }}-${{ inputs.use-cmake-presets && inputs.preset-name || inputs.config }}
   cancel-in-progress: true
 
 permissions:
@@ -71,7 +71,7 @@ permissions:
 
 jobs:
   cpp-tests-ubuntu:
-    name: 🐧 ${{ inputs.runs-on }} ${{ inputs.compiler }} ${{ inputs.config }}
+    name: 🐧 ${{ inputs.runs-on }} ${{ inputs.compiler }} ${{ inputs.use-cmake-presets && inputs.preset-name || inputs.config }}
     runs-on: ${{ inputs.runs-on }}
     env:
       CMAKE_BUILD_PARALLEL_LEVEL: 4

--- a/.github/workflows/reusable-cpp-tests-ubuntu.yml
+++ b/.github/workflows/reusable-cpp-tests-ubuntu.yml
@@ -53,6 +53,14 @@ on:
         description: "The LLVM version to set up (formatted as 'major.minor.patch') or commit hash (minimum 7 characters, e.g., 'a832a52')"
         default: "21.1.8"
         type: string
+      use-cmake-presets:
+        description: "Whether to use CMake presets for configuration and build."
+        default: false
+        type: boolean
+      preset-name:
+        description: "The CMake preset to use for configuration and build."
+        default: ""
+        type: string
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}-cpp-tests-${{ inputs.runs-on }}-${{ inputs.compiler }}-${{ inputs.config }}
@@ -140,6 +148,7 @@ jobs:
           echo "CXX=clang++-$version" >> $GITHUB_ENV
 
       - name: Configure CMake
+        if: ${{ !inputs.use-cmake-presets }}
         env:
           CONFIG: ${{ inputs.config }}
           CMAKE_ARGS: ${{ inputs.cmake-args }}
@@ -151,10 +160,28 @@ jobs:
           fi
           cmake -G Ninja -S . -B build -DCMAKE_BUILD_TYPE=$CONFIG $CMAKE_ARGS "$LIT_ARG"
 
+      - name: Configure CMake with cmake-presets
+        if: ${{ inputs.use-cmake-presets }}
+        env:
+          PRESET_NAME: ${{ inputs.preset-name }}
+          SETUP_MLIR: ${{ inputs.setup-mlir }}
+        run: |
+          LIT_ARG=""
+          if [ "$SETUP_MLIR" = "true" ]; then
+            LIT_ARG="-DLLVM_EXTERNAL_LIT=$(which lit)"
+          fi
+          cmake --preset "$PRESET_NAME" "$LIT_ARG"
+
       - name: Build
         env:
           CONFIG: ${{ inputs.config }}
         run: cmake --build build --config $CONFIG
+
+      - name: Build with cmake-presets
+        if: ${{ inputs.use-cmake-presets }}
+        env:
+          PRESET_NAME: ${{ inputs.preset-name }}
+        run: cmake --build --preset "$PRESET_NAME"
 
       - name: Test
         env:

--- a/.github/workflows/reusable-cpp-tests-ubuntu.yml
+++ b/.github/workflows/reusable-cpp-tests-ubuntu.yml
@@ -111,7 +111,9 @@ jobs:
 
       - name: Install lit
         if: ${{ inputs.setup-mlir }}
-        run: uv pip install lit
+        run: |
+          uv pip install lit
+          echo "LIT_BIN=$(which lit)" >> $GITHUB_ENV
 
       - name: Set up default Clang
         if: ${{ inputs.compiler == 'clang' }}
@@ -164,13 +166,7 @@ jobs:
         if: ${{ inputs.use-cmake-presets }}
         env:
           PRESET_NAME: ${{ inputs.preset-name }}
-          SETUP_MLIR: ${{ inputs.setup-mlir }}
-        run: |
-          LIT_ARG=""
-          if [ "$SETUP_MLIR" = "true" ]; then
-            LIT_ARG="-DLLVM_EXTERNAL_LIT=$(which lit)"
-          fi
-          cmake --preset "$PRESET_NAME" "$LIT_ARG"
+        run: cmake --preset "$PRESET_NAME"
 
       - name: Build
         if: ${{ !inputs.use-cmake-presets }}

--- a/.github/workflows/reusable-cpp-tests-ubuntu.yml
+++ b/.github/workflows/reusable-cpp-tests-ubuntu.yml
@@ -16,12 +16,6 @@ on:
           This can be any valid Ubuntu runner image, such as 'ubuntu-24.04' or its ARM variant 'ubuntu-24.04-arm'.
         default: "ubuntu-24.04"
         type: string
-      config:
-        description: >
-          The build type to use. Defaults to 'Release'.
-          This can be any valid CMake build type, such as 'Debug' or 'Release'.
-        default: "Release"
-        type: string
       compiler:
         description: >
           The compiler to use. Defaults to 'gcc'.
@@ -30,12 +24,6 @@ on:
           If 'clang' is selected, the default Clang compiler will be used.
           A specific version of Clang can be requested via 'clang-XX', where XX is the version number (e.g., 'clang-20').
         default: "gcc"
-        type: string
-      cmake-args:
-        description: >
-          Additional arguments to pass to CMake. Defaults to an empty string.
-          This can be any valid CMake argument, such as '-DBUILD_SHARED_LIBS=ON'.
-        default: ""
         type: string
       setup-z3:
         description: "Whether to set up Z3"
@@ -53,17 +41,13 @@ on:
         description: "The LLVM version to set up (formatted as 'major.minor.patch') or commit hash (minimum 7 characters, e.g., 'a832a52')"
         default: "21.1.8"
         type: string
-      use-cmake-presets:
-        description: "Whether to use cmake-presets"
-        default: false
-        type: boolean
       preset-name:
         description: "The CMake preset to use for configuration and build."
         default: ""
         type: string
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}-cpp-tests-${{ inputs.runs-on }}-${{ inputs.compiler }}-${{ inputs.use-cmake-presets && inputs.preset-name || inputs.config }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}-cpp-tests-${{ inputs.runs-on }}-${{ inputs.compiler }}-${{ inputs.preset-name }}
   cancel-in-progress: true
 
 permissions:
@@ -71,7 +55,7 @@ permissions:
 
 jobs:
   cpp-tests-ubuntu:
-    name: 🐧 ${{ inputs.runs-on }} ${{ inputs.compiler }} ${{ inputs.use-cmake-presets && inputs.preset-name || inputs.config }}
+    name: 🐧 ${{ inputs.runs-on }} ${{ inputs.compiler }} ${{ inputs.preset-name }}
     runs-on: ${{ inputs.runs-on }}
     env:
       CMAKE_BUILD_PARALLEL_LEVEL: 4
@@ -150,44 +134,16 @@ jobs:
           echo "CXX=clang++-$version" >> $GITHUB_ENV
 
       - name: Configure CMake
-        if: ${{ !inputs.use-cmake-presets }}
-        env:
-          CONFIG: ${{ inputs.config }}
-          CMAKE_ARGS: ${{ inputs.cmake-args }}
-          SETUP_MLIR: ${{ inputs.setup-mlir }}
-        run: |
-          LIT_ARG=""
-          if [ "$SETUP_MLIR" = "true" ]; then
-            LIT_ARG="-DLLVM_EXTERNAL_LIT=$(which lit)"
-          fi
-          cmake -G Ninja -S . -B build -DCMAKE_BUILD_TYPE=$CONFIG $CMAKE_ARGS "$LIT_ARG"
-
-      - name: Configure CMake with cmake-presets
-        if: ${{ inputs.use-cmake-presets }}
         env:
           PRESET_NAME: ${{ inputs.preset-name }}
         run: cmake --preset "$PRESET_NAME"
 
       - name: Build
-        if: ${{ !inputs.use-cmake-presets }}
-        env:
-          CONFIG: ${{ inputs.config }}
-        run: cmake --build build --config $CONFIG
-
-      - name: Build with cmake-presets
-        if: ${{ inputs.use-cmake-presets }}
         env:
           PRESET_NAME: ${{ inputs.preset-name }}
         run: cmake --build --preset "$PRESET_NAME"
 
       - name: Test
-        if: ${{ !inputs.use-cmake-presets }}
-        env:
-          CONFIG: ${{ inputs.config }}
-        run: ctest -C $CONFIG --output-on-failure --test-dir build --repeat until-pass:3 --timeout 600
-
-      - name: Test with cmake-presets
-        if: ${{ inputs.use-cmake-presets }}
         env:
           PRESET_NAME: ${{ inputs.preset-name }}
         run: ctest --preset "$PRESET_NAME"

--- a/.github/workflows/reusable-cpp-tests-windows.yml
+++ b/.github/workflows/reusable-cpp-tests-windows.yml
@@ -146,6 +146,13 @@ jobs:
         run: cmake --build --preset "$PRESET_NAME"
 
       - name: Test
+        if: ${{ !inputs.use-cmake-presets }}
         env:
           CONFIG: ${{ inputs.config }}
         run: ctest -C $CONFIG --output-on-failure --test-dir build --repeat until-pass:3 --timeout 600
+
+      - name: Test with cmake-presets
+        if: ${{ inputs.use-cmake-presets }}
+        env:
+          PRESET_NAME: ${{ inputs.preset-name }}
+        run: ctest --preset "$PRESET_NAME"

--- a/.github/workflows/reusable-cpp-tests-windows.yml
+++ b/.github/workflows/reusable-cpp-tests-windows.yml
@@ -51,6 +51,14 @@ on:
         description: "The LLVM version to set up (formatted as 'major.minor.patch') or commit hash (minimum 7 characters, e.g., 'a832a52')"
         default: "21.1.8"
         type: string
+      use-cmake-presets:
+        description: "Whether to use CMake presets for configuration and build."
+        default: false
+        type: boolean
+      preset-name:
+        description: "The CMake preset to use for configuration and build."
+        default: ""
+        type: string
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}-cpp-tests-${{ inputs.runs-on }}-${{ inputs.compiler }}-${{ inputs.config }}
@@ -103,6 +111,7 @@ jobs:
         run: uv pip install lit
 
       - name: Configure CMake
+        if: ${{ !inputs.use-cmake-presets }}
         env:
           CONFIG: ${{ inputs.config }}
           CMAKE_ARGS: ${{ inputs.cmake-args }}
@@ -115,11 +124,26 @@ jobs:
           fi
           cmake -S . -B build -DCMAKE_BUILD_TYPE=$CONFIG $cmake_args $LIT_ARG
 
+      - name: Configure CMake with cmake-presets
+        if: ${{ inputs.use-cmake-presets }}
+        env:
+          PRESET_NAME: ${{ inputs.preset-name }}
+          LIT_ARG: ${{ inputs.setup-mlir && format('-DLLVM_EXTERNAL_LIT={0}/.venv/Scripts/lit.exe', github.workspace) || '' }}
+        run: cmake --preset "$PRESET_NAME" "$LIT_ARG"
+
       - name: Build
+        if: ${{ !inputs.use-cmake-presets }}
         timeout-minutes: 60
         env:
           CONFIG: ${{ inputs.config }}
         run: cmake --build build --config $CONFIG
+
+      - name: Build with cmake-presets
+        if: ${{ inputs.use-cmake-presets }}
+        timeout-minutes: 60
+        env:
+          PRESET_NAME: ${{ inputs.preset-name }}
+        run: cmake --build --preset "$PRESET_NAME"
 
       - name: Test
         env:

--- a/.github/workflows/reusable-cpp-tests-windows.yml
+++ b/.github/workflows/reusable-cpp-tests-windows.yml
@@ -108,7 +108,9 @@ jobs:
 
       - name: Install lit
         if: ${{ inputs.setup-mlir }}
-        run: uv pip install lit
+        run: |
+          uv pip install lit
+          echo "LIT_BIN=$(format('{0}/.venv/Scripts/lit.exe', github.workspace))" >> $GITHUB_ENV
 
       - name: Configure CMake
         if: ${{ !inputs.use-cmake-presets }}
@@ -128,8 +130,7 @@ jobs:
         if: ${{ inputs.use-cmake-presets }}
         env:
           PRESET_NAME: ${{ inputs.preset-name }}
-          LIT_ARG: ${{ inputs.setup-mlir && format('-DLLVM_EXTERNAL_LIT={0}/.venv/Scripts/lit.exe', github.workspace) || '' }}
-        run: cmake --preset "$PRESET_NAME" "$LIT_ARG"
+        run: cmake --preset "$PRESET_NAME"
 
       - name: Build
         if: ${{ !inputs.use-cmake-presets }}

--- a/.github/workflows/reusable-cpp-tests-windows.yml
+++ b/.github/workflows/reusable-cpp-tests-windows.yml
@@ -110,7 +110,7 @@ jobs:
         if: ${{ inputs.setup-mlir }}
         run: |
           uv pip install lit
-          echo "LIT_BIN=$(which lit)" >> $GITHUB_ENV
+          echo "LIT_BIN=$GITHUB_WORKSPACE/.venv/Scripts/lit.exe" >> $GITHUB_ENV
 
       - name: Configure CMake
         if: ${{ !inputs.use-cmake-presets }}

--- a/.github/workflows/reusable-cpp-tests-windows.yml
+++ b/.github/workflows/reusable-cpp-tests-windows.yml
@@ -61,7 +61,7 @@ on:
         type: string
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}-cpp-tests-${{ inputs.runs-on }}-${{ inputs.compiler }}-${{ inputs.config }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}-cpp-tests-${{ inputs.runs-on }}-${{ inputs.compiler }}-${{ inputs.use-cmake-presets && inputs.preset-name || inputs.config }}
   cancel-in-progress: true
 
 permissions:
@@ -73,7 +73,7 @@ defaults:
 
 jobs:
   cpp-tests-windows:
-    name: 🏁 ${{ inputs.runs-on }} ${{ inputs.compiler }} ${{ inputs.config }}
+    name: 🏁 ${{ inputs.runs-on }} ${{ inputs.compiler }} ${{ inputs.use-cmake-presets && inputs.preset-name || inputs.config }}
     runs-on: ${{ inputs.runs-on }}
     env:
       CMAKE_BUILD_PARALLEL_LEVEL: 4

--- a/.github/workflows/reusable-cpp-tests-windows.yml
+++ b/.github/workflows/reusable-cpp-tests-windows.yml
@@ -16,24 +16,12 @@ on:
           This can be any valid Windows runner image, such as 'windows-2022' or 'windows-2025'.
         default: "windows-latest"
         type: string
-      config:
-        description: >
-          The build type to use. Defaults to 'Release'.
-          This can be any valid CMake build type, such as 'Debug' or 'Release'.
-        default: "Release"
-        type: string
       compiler:
         description: >
           The compiler to use. Defaults to 'msvc'.
           This can be 'msvc' or 'clang'.
           If 'clang' is selected, '-T ClangCL' is automatically added to the CMake arguments.
         default: "msvc"
-        type: string
-      cmake-args:
-        description: >
-          Additional arguments to pass to CMake. Defaults to an empty string.
-          This can be any valid CMake argument, such as '-DBUILD_SHARED_LIBS=ON'.
-        default: ""
         type: string
       setup-z3:
         description: "Whether to set up Z3"
@@ -51,17 +39,13 @@ on:
         description: "The LLVM version to set up (formatted as 'major.minor.patch') or commit hash (minimum 7 characters, e.g., 'a832a52')"
         default: "21.1.8"
         type: string
-      use-cmake-presets:
-        description: "Whether to use cmake-presets"
-        default: false
-        type: boolean
       preset-name:
         description: "The CMake preset to use for configuration and build."
         default: ""
         type: string
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}-cpp-tests-${{ inputs.runs-on }}-${{ inputs.compiler }}-${{ inputs.use-cmake-presets && inputs.preset-name || inputs.config }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}-cpp-tests-${{ inputs.runs-on }}-${{ inputs.compiler }}-${{ inputs.preset-name }}
   cancel-in-progress: true
 
 permissions:
@@ -73,7 +57,7 @@ defaults:
 
 jobs:
   cpp-tests-windows:
-    name: 🏁 ${{ inputs.runs-on }} ${{ inputs.compiler }} ${{ inputs.use-cmake-presets && inputs.preset-name || inputs.config }}
+    name: 🏁 ${{ inputs.runs-on }} ${{ inputs.compiler }} ${{ inputs.preset-name }}
     runs-on: ${{ inputs.runs-on }}
     env:
       CMAKE_BUILD_PARALLEL_LEVEL: 4
@@ -97,7 +81,7 @@ jobs:
         uses: munich-quantum-software/setup-mlir@883c1e05e60abbc215e967cde7d3ca7fde378e8d # v1.3.1
         with:
           llvm-version: ${{ inputs.llvm-version }}
-          debug: ${{ inputs.use-cmake-presets && contains(inputs.preset-name, 'debug') || inputs.config == 'Debug' }}
+          debug: ${{ contains(inputs.preset-name, 'debug') }}
 
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
@@ -113,47 +97,17 @@ jobs:
           echo "LIT_BIN=$GITHUB_WORKSPACE/.venv/Scripts/lit.exe" >> $GITHUB_ENV
 
       - name: Configure CMake
-        if: ${{ !inputs.use-cmake-presets }}
-        env:
-          CONFIG: ${{ inputs.config }}
-          CMAKE_ARGS: ${{ inputs.cmake-args }}
-          COMPILER: ${{ inputs.compiler }}
-          LIT_ARG: ${{ inputs.setup-mlir && format('-DLLVM_EXTERNAL_LIT={0}/.venv/Scripts/lit.exe', github.workspace) || '' }}
-        run: |
-          cmake_args=$CMAKE_ARGS
-          if [ "$COMPILER" == "clang" ]; then
-            cmake_args="$cmake_args -T ClangCL"
-          fi
-          cmake -S . -B build -DCMAKE_BUILD_TYPE=$CONFIG $cmake_args $LIT_ARG
-
-      - name: Configure CMake with cmake-presets
-        if: ${{ inputs.use-cmake-presets }}
         env:
           PRESET_NAME: ${{ inputs.preset-name }}
         run: cmake --preset "$PRESET_NAME"
 
       - name: Build
-        if: ${{ !inputs.use-cmake-presets }}
-        timeout-minutes: 60
-        env:
-          CONFIG: ${{ inputs.config }}
-        run: cmake --build build --config $CONFIG
-
-      - name: Build with cmake-presets
-        if: ${{ inputs.use-cmake-presets }}
         timeout-minutes: 60
         env:
           PRESET_NAME: ${{ inputs.preset-name }}
         run: cmake --build --preset "$PRESET_NAME"
 
       - name: Test
-        if: ${{ !inputs.use-cmake-presets }}
-        env:
-          CONFIG: ${{ inputs.config }}
-        run: ctest -C $CONFIG --output-on-failure --test-dir build --repeat until-pass:3 --timeout 600
-
-      - name: Test with cmake-presets
-        if: ${{ inputs.use-cmake-presets }}
         env:
           PRESET_NAME: ${{ inputs.preset-name }}
         run: ctest --preset "$PRESET_NAME"

--- a/.github/workflows/reusable-cpp-tests-windows.yml
+++ b/.github/workflows/reusable-cpp-tests-windows.yml
@@ -52,7 +52,7 @@ on:
         default: "21.1.8"
         type: string
       use-cmake-presets:
-        description: "Whether to use CMake presets for configuration and build."
+        description: "Whether to use cmake-presets"
         default: false
         type: boolean
       preset-name:

--- a/.github/workflows/reusable-cpp-tests-windows.yml
+++ b/.github/workflows/reusable-cpp-tests-windows.yml
@@ -110,7 +110,7 @@ jobs:
         if: ${{ inputs.setup-mlir }}
         run: |
           uv pip install lit
-          echo "LIT_BIN=$(format('{0}/.venv/Scripts/lit.exe', github.workspace))" >> $GITHUB_ENV
+          echo "LIT_BIN=$(which lit)" >> $GITHUB_ENV
 
       - name: Configure CMake
         if: ${{ !inputs.use-cmake-presets }}

--- a/.github/workflows/reusable-cpp-tests-windows.yml
+++ b/.github/workflows/reusable-cpp-tests-windows.yml
@@ -97,7 +97,7 @@ jobs:
         uses: munich-quantum-software/setup-mlir@f3ebc0bd966545a052741bc2b31750c34a09aa22 # v1.3.0
         with:
           llvm-version: ${{ inputs.llvm-version }}
-          debug: ${{ inputs.config == 'Debug' }}
+          debug: ${{ inputs.use-cmake-presets && inputs.preset-name == 'debug' || inputs.config == 'Debug' }}
 
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0

--- a/.github/workflows/reusable-cpp-tests-windows.yml
+++ b/.github/workflows/reusable-cpp-tests-windows.yml
@@ -97,7 +97,7 @@ jobs:
         uses: munich-quantum-software/setup-mlir@f3ebc0bd966545a052741bc2b31750c34a09aa22 # v1.3.0
         with:
           llvm-version: ${{ inputs.llvm-version }}
-          debug: ${{ inputs.use-cmake-presets && inputs.preset-name == 'debug' || inputs.config == 'Debug' }}
+          debug: ${{ inputs.use-cmake-presets && contains(inputs.preset-name, 'debug') || inputs.config == 'Debug' }}
 
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0

--- a/.github/workflows/reusable-cpp-tests-windows.yml
+++ b/.github/workflows/reusable-cpp-tests-windows.yml
@@ -39,8 +39,12 @@ on:
         description: "The LLVM version to set up (formatted as 'major.minor.patch') or commit hash (minimum 7 characters, e.g., 'a832a52')"
         default: "21.1.8"
         type: string
+      mlir-debug:
+        description: "Whether to use a debug build of MLIR"
+        default: false
+        type: boolean
       preset-name:
-        description: "The CMake preset to use for configuration and build."
+        description: "The CMake preset to use for configuration and build"
         required: true
         type: string
 
@@ -81,7 +85,7 @@ jobs:
         uses: munich-quantum-software/setup-mlir@883c1e05e60abbc215e967cde7d3ca7fde378e8d # v1.3.1
         with:
           llvm-version: ${{ inputs.llvm-version }}
-          debug: ${{ contains(inputs.preset-name, 'debug') }}
+          debug: ${{ inputs.mlir-debug }}
 
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0

--- a/.github/workflows/reusable-cpp-tests-windows.yml
+++ b/.github/workflows/reusable-cpp-tests-windows.yml
@@ -41,7 +41,7 @@ on:
         type: string
       preset-name:
         description: "The CMake preset to use for configuration and build."
-        default: ""
+        required: true
         type: string
 
 concurrency:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ _If you are upgrading: please see [`UPGRADING.md`](UPGRADING.md#200)._
 ### Changed
 
 - 🚸 Adapt C++ workflows to require `cmake-presets` ([#363]) ([**@denialhaag**])
+- ♻️ Add `mlir-debug` flag for requesting debug build of MLIR on Windows ([#363]) ([**@denialhaag**])
 
 ## [1.18.1] - 2026-04-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ This project adheres to [Semantic Versioning], with the exception that minor rel
 
 ## [Unreleased]
 
+## [2.0.0] - 2026-05-22
+
+_If you are upgrading: please see [`UPGRADING.md`](UPGRADING.md#200)._
+
+### Changed
+
+- 🚸 Adapt C++ workflows to require `cmake-presets` ([#363]) ([**@denialhaag**])
+
 ## [1.18.1] - 2026-04-09
 
 _If you are upgrading: please see [`UPGRADING.md`](UPGRADING.md#1181)._
@@ -303,7 +311,8 @@ _📚 Refer to the [GitHub Release Notes] for previous changelogs._
 
 <!-- Version links -->
 
-[unreleased]: https://github.com/munich-quantum-toolkit/workflows/compare/v1.18.1...HEAD
+[unreleased]: https://github.com/munich-quantum-toolkit/workflows/compare/v2.0.0...HEAD
+[2.0.0]: https://github.com/munich-quantum-toolkit/workflows/releases/tag/v2.0.0
 [1.18.1]: https://github.com/munich-quantum-toolkit/workflows/releases/tag/v1.18.1
 [1.18.0]: https://github.com/munich-quantum-toolkit/workflows/releases/tag/v1.18.0
 [1.17.15]: https://github.com/munich-quantum-toolkit/workflows/releases/tag/v1.17.15
@@ -337,6 +346,7 @@ _📚 Refer to the [GitHub Release Notes] for previous changelogs._
 
 <!-- PR links -->
 
+[#363]: https://github.com/munich-quantum-toolkit/workflows/pull/363
 [#356]: https://github.com/munich-quantum-toolkit/workflows/pull/356
 [#344]: https://github.com/munich-quantum-toolkit/workflows/pull/344
 [#343]: https://github.com/munich-quantum-toolkit/workflows/pull/343

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ _If you are upgrading: please see [`UPGRADING.md`](UPGRADING.md#200)._
 ### Changed
 
 - 🚸 Adapt C++ workflows to require [CMake presets] ([#363]) ([**@denialhaag**])
-- ♻️ Add `mlir-debug` flag for requesting debug build of MLIR on Windows ([#363]) ([**@denialhaag**])
+- ♻️ Add `mlir-debug` flag to the `reusable-cpp-tests-windows` workflow for requesting a debug build of MLIR ([#363]) ([**@denialhaag**])
 
 ## [1.18.1] - 2026-04-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ _If you are upgrading: please see [`UPGRADING.md`](UPGRADING.md#200)._
 
 ### Changed
 
-- 🚸 Adapt C++ workflows to require `cmake-presets` ([#363]) ([**@denialhaag**])
+- 🚸 Adapt C++ workflows to require CMake presets ([#363]) ([**@denialhaag**])
 - ♻️ Add `mlir-debug` flag for requesting debug build of MLIR on Windows ([#363]) ([**@denialhaag**])
 
 ## [1.18.1] - 2026-04-09

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ _If you are upgrading: please see [`UPGRADING.md`](UPGRADING.md#200)._
 
 ### Changed
 
-- 🚸 Adapt C++ workflows to require CMake presets ([#363]) ([**@denialhaag**])
+- 🚸 Adapt C++ workflows to require [CMake presets] ([#363]) ([**@denialhaag**])
 - ♻️ Add `mlir-debug` flag for requesting debug build of MLIR on Windows ([#363]) ([**@denialhaag**])
 
 ## [1.18.1] - 2026-04-09
@@ -408,3 +408,4 @@ _📚 Refer to the [GitHub Release Notes] for previous changelogs._
 [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
 [GitHub Release Notes]: https://github.com/munich-quantum-toolkit/workflows/releases
 [munich-quantum-software/setup-mlir]: https://github.com/munich-quantum-software/setup-mlir
+[CMake presets]: https://cmake.org/cmake/help/latest/manual/cmake-presets.7.html

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -6,14 +6,12 @@ This document describes breaking changes and how to upgrade. For a complete list
 
 ## [2.0.0]
 
-This release adapts all C++ workflows to require CMake presets.
+This release adapts all C++ workflows to require [CMake presets], providing a standardized and reproducible way to configure builds across different platforms while eliminating scattered configuration with string-based arguments.
 
-In particular, `reusable-cpp-tests-macos.yml`, `reusable-cpp-tests-ubuntu.yml`, and `reusable-cpp-tests-windows.yml` have a new required `preset-name` input.
-The `cmake-args` and `config` inputs are no longer available.
-If a debug build of MLIR is required on Windows, the newly added `debug-mlir` flag may be used.
+The testing workflows for macOS, Ubuntu, and Windows (`reusable-cpp-tests-macos.yml`, `reusable-cpp-tests-ubuntu.yml`, and `reusable-cpp-tests-windows.yml`) now require a `preset-name` input and no longer accept `cmake-args` or `config` inputs.
+On Windows, the new `debug-mlir` flag can be used for debug MLIR builds.
 
-`reusable-cpp-coverage.yml` and `reusable-cpp-linter.yml` require the definition of `coverage` and `lint` presets, respectively.
-They also lose the `cmake-args` input.
+The coverage and linter workflows (`reusable-cpp-coverage.yml` and `reusable-cpp-linter.yml`) require `coverage` and `lint` presets, respectively, and no longer accept `cmake-args`.
 
 An exemplary `CMakePresets.json` can be found below.
 
@@ -487,3 +485,4 @@ Consider removing any `-G Ninja` flags from your CMake invocations under Windows
 [portable-mlir-toolchain]: https://github.com/munich-quantum-software/portable-mlir-toolchain
 [setup-mlir]: https://github.com/munich-quantum-software/setup-mlir
 [zizmor]: https://docs.zizmor.sh/
+[CMake presets]: https://cmake.org/cmake/help/latest/manual/cmake-presets.7.html

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -9,7 +9,7 @@ This document describes breaking changes and how to upgrade. For a complete list
 This release adapts all C++ workflows to require [CMake presets], providing a standardized and reproducible way to configure builds across different platforms while eliminating scattered configuration with string-based arguments.
 
 The testing workflows for macOS, Ubuntu, and Windows (`reusable-cpp-tests-macos.yml`, `reusable-cpp-tests-ubuntu.yml`, and `reusable-cpp-tests-windows.yml`) now require a `preset-name` input and no longer accept `cmake-args` or `config` inputs.
-On Windows, the new `debug-mlir` flag can be used for debug MLIR builds.
+On Windows, the new `mlir-debug` flag can be used for debug MLIR builds.
 
 The coverage and linter workflows (`reusable-cpp-coverage.yml` and `reusable-cpp-linter.yml`) require `coverage` and `lint` presets, respectively, and no longer accept `cmake-args`.
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -4,6 +4,172 @@ This document describes breaking changes and how to upgrade. For a complete list
 
 ## [Unreleased]
 
+## [2.0.0]
+
+This release adapts all C++ workflows to require `cmake-presets`.
+
+In particular, `reusable-cpp-tests-macos.yml`, `reusable-cpp-tests-ubuntu.yml`, and `reusable-cpp-tests-windows.yml` have a new required `preset-name` input.
+The `cmake-args` and `config` inputs are no longer available.
+
+`reusable-cpp-coverage.yml` and `reusable-cpp-linter.yml` require the definition of `coverage` and `lint` presets, respectively.
+They also lose the `cmake-args` input.
+
+An exemplary `CMakePresets.json` can be found below.
+
+```json
+{
+  "version": 3,
+  "configurePresets": [
+    {
+      "name": "base",
+      "hidden": true,
+      "binaryDir": "${sourceDir}/build/${presetName}",
+      "cacheVariables": {
+        "MLIR_DIR": "$env{MLIR_DIR}"
+      }
+    },
+    {
+      "name": "base-unix",
+      "hidden": true,
+      "inherits": "base",
+      "condition": {
+        "type": "inList",
+        "string": "${hostSystemName}",
+        "list": ["Linux", "Darwin"]
+      },
+      "description": "Default configuration for Linux and macOS builds. Uses the Ninja generator",
+      "generator": "Ninja"
+    },
+    {
+      "name": "base-windows",
+      "hidden": true,
+      "inherits": "base",
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Windows"
+      },
+      "description": "Default configuration for Windows builds. Uses the default generator"
+    },
+    {
+      "name": "debug",
+      "inherits": "base-unix",
+      "displayName": "Debug config",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "LLVM_ENABLE_ASSERTIONS": "ON"
+      }
+    },
+    {
+      "name": "release",
+      "inherits": "base-unix",
+      "displayName": "Release config",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release"
+      }
+    },
+    {
+      "name": "coverage",
+      "inherits": "base-unix",
+      "displayName": "Coverage config",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "ENABLE_COVERAGE": "ON"
+      }
+    },
+    {
+      "name": "lint",
+      "inherits": "base-unix",
+      "displayName": "Lint config",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "BUILD_MQT_CORE_BENCHMARKS": "ON",
+        "BUILD_MQT_CORE_BINDINGS": "ON"
+      }
+    },
+    {
+      "name": "debug-windows",
+      "inherits": "base-windows",
+      "displayName": "Windows Debug config",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "LLVM_ENABLE_ASSERTIONS": "ON"
+      }
+    },
+    {
+      "name": "release-windows",
+      "inherits": "base-windows",
+      "displayName": "Windows Release config",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release"
+      }
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "debug",
+      "configurePreset": "debug"
+    },
+    {
+      "name": "release",
+      "configurePreset": "release"
+    },
+    {
+      "name": "coverage",
+      "configurePreset": "coverage"
+    },
+    {
+      "name": "lint",
+      "configurePreset": "lint"
+    },
+    {
+      "name": "debug-windows",
+      "configurePreset": "debug-windows",
+      "configuration": "Debug"
+    },
+    {
+      "name": "release-windows",
+      "configurePreset": "release-windows",
+      "configuration": "Release"
+    }
+  ],
+  "testPresets": [
+    {
+      "name": "base",
+      "hidden": true,
+      "output": { "outputOnFailure": true }
+    },
+    {
+      "name": "debug",
+      "inherits": "base",
+      "configurePreset": "debug"
+    },
+    {
+      "name": "release",
+      "inherits": "base",
+      "configurePreset": "release"
+    },
+    {
+      "name": "coverage",
+      "inherits": "base",
+      "configurePreset": "coverage"
+    },
+    {
+      "name": "debug-windows",
+      "inherits": "base",
+      "configurePreset": "debug-windows",
+      "configuration": "Debug"
+    },
+    {
+      "name": "release-windows",
+      "inherits": "base",
+      "configurePreset": "release-windows",
+      "configuration": "Release"
+    }
+  ]
+}
+```
+
 ## [1.18.1]
 
 To reduce complications when uploading artifacts during deployment to PyPI, we are reverting changes made in [1.17.15].
@@ -294,7 +460,8 @@ Consider removing any `-G Ninja` flags from your CMake invocations under Windows
 
 <!-- Version links -->
 
-[unreleased]: https://github.com/munich-quantum-toolkit/workflows/compare/v1.18.1...HEAD
+[unreleased]: https://github.com/munich-quantum-toolkit/workflows/compare/v2.0.0...HEAD
+[2.0.0]: https://github.com/munich-quantum-toolkit/workflows/compare/v1.18.1...v2.0.0
 [1.18.1]: https://github.com/munich-quantum-toolkit/workflows/compare/v1.18.0...v1.18.1
 [1.18.0]: https://github.com/munich-quantum-toolkit/workflows/compare/v1.17.15...v1.18.0
 [1.17.15]: https://github.com/munich-quantum-toolkit/workflows/compare/v1.17.11...v1.17.15

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -10,6 +10,7 @@ This release adapts all C++ workflows to require `cmake-presets`.
 
 In particular, `reusable-cpp-tests-macos.yml`, `reusable-cpp-tests-ubuntu.yml`, and `reusable-cpp-tests-windows.yml` have a new required `preset-name` input.
 The `cmake-args` and `config` inputs are no longer available.
+If a debug build of MLIR is required on Windows, the newly added `debug-mlir` flag may be used.
 
 `reusable-cpp-coverage.yml` and `reusable-cpp-linter.yml` require the definition of `coverage` and `lint` presets, respectively.
 They also lose the `cmake-args` input.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -6,7 +6,7 @@ This document describes breaking changes and how to upgrade. For a complete list
 
 ## [2.0.0]
 
-This release adapts all C++ workflows to require `cmake-presets`.
+This release adapts all C++ workflows to require CMake presets.
 
 In particular, `reusable-cpp-tests-macos.yml`, `reusable-cpp-tests-ubuntu.yml`, and `reusable-cpp-tests-windows.yml` have a new required `preset-name` input.
 The `cmake-args` and `config` inputs are no longer available.


### PR DESCRIPTION
## Description

This PR adapts the C++ workflows to require [CMake presets](https://cmake.org/cmake/help/latest/manual/cmake-presets.7.html).

Fixes #352 

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] ~~I have added appropriate tests that cover the new/changed functionality.~~
- [x] ~~I have updated the documentation to reflect these changes.~~
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.
