### PR TITLE
🐛 Hardcode build directory in `reusable-cpp-linter.yml`

### DIFF
--- a/.github/workflows/reusable-cpp-linter.yml
+++ b/.github/workflows/reusable-cpp-linter.yml
@@ -155,11 +155,11 @@ jobs:
           fi
 
       - name: Generate compilation database
-        run: cmake --preset lint
+        run: cmake -B build --preset lint
 
       - name: Build
         if: ${{ inputs.build-project }}
-        run: cmake --build --preset lint
+        run: cmake --build build
 
       # runs the cpp-linter action using the generated compilation database and the specified clang version
       - name: Run cpp-linter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ This project adheres to [Semantic Versioning], with the exception that minor rel
 
 ## [Unreleased]
 
+## [2.0.1] - 2026-05-22
+
+### Fixed
+
+🐛 Hardcode build directory in `reusable-cpp-linter.yml` ([#377]) ([**@denialhaag**])
+
 ## [2.0.0] - 2026-05-22
 
 _If you are upgrading: please see [`UPGRADING.md`](UPGRADING.md#200)._
@@ -312,7 +318,8 @@ _📚 Refer to the [GitHub Release Notes] for previous changelogs._
 
 <!-- Version links -->
 
-[unreleased]: https://github.com/munich-quantum-toolkit/workflows/compare/v2.0.0...HEAD
+[unreleased]: https://github.com/munich-quantum-toolkit/workflows/compare/v2.0.1...HEAD
+[2.0.1]: https://github.com/munich-quantum-toolkit/workflows/releases/tag/v2.0.1
 [2.0.0]: https://github.com/munich-quantum-toolkit/workflows/releases/tag/v2.0.0
 [1.18.1]: https://github.com/munich-quantum-toolkit/workflows/releases/tag/v1.18.1
 [1.18.0]: https://github.com/munich-quantum-toolkit/workflows/releases/tag/v1.18.0
@@ -347,6 +354,7 @@ _📚 Refer to the [GitHub Release Notes] for previous changelogs._
 
 <!-- PR links -->
 
+[#377]: https://github.com/munich-quantum-toolkit/workflows/pull/377
 [#363]: https://github.com/munich-quantum-toolkit/workflows/pull/363
 [#356]: https://github.com/munich-quantum-toolkit/workflows/pull/356
 [#344]: https://github.com/munich-quantum-toolkit/workflows/pull/344


### PR DESCRIPTION
## Description

This PR hardcodes the build directory in `reusable-cpp-linter.yml` so that `clang-tidy` can always find the compilation database.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] ~~I have added appropriate tests that cover the new/changed functionality.~~
- [x] ~~I have updated the documentation to reflect these changes.~~
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] ~~I have added migration instructions to the upgrade guide (if needed).~~
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.
