### PR TITLE
🐛 Ensure `reusable-mqt-core-update.yml` runs against `main`

### DIFF
--- a/.github/workflows/reusable-mqt-core-update.yml
+++ b/.github/workflows/reusable-mqt-core-update.yml
@@ -50,6 +50,7 @@ jobs:
       # Check out the repository
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          ref: main
           fetch-depth: 0
           persist-credentials: false
       # Parse the MQT Core version and the revision from the `cmake/ExternalDependencies.cmake` file.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This project adheres to [Semantic Versioning], with the exception that minor rel
 
 ## [Unreleased]
 
+### Fixed
+
+🐛 Ensure `reusable-mqt-core-update.yml` runs against `main` ([#380]) ([**@denialhaag**])
+
 ## [2.0.1] - 2026-05-22
 
 ### Fixed
@@ -22,7 +26,7 @@ _If you are upgrading: please see [`UPGRADING.md`](UPGRADING.md#200)._
 ### Changed
 
 - 🚸 Adapt C++ workflows to require [CMake presets] ([#363]) ([**@denialhaag**])
-- ♻️ Add `mlir-debug` flag to the `reusable-cpp-tests-windows` workflow for requesting a debug build of MLIR ([#363]) ([**@denialhaag**])
+- ♻️ Add `mlir-debug` flag to `reusable-cpp-tests-windows.yml` for requesting a debug build of MLIR ([#363]) ([**@denialhaag**])
 
 ## [1.18.1] - 2026-04-09
 
@@ -354,6 +358,7 @@ _📚 Refer to the [GitHub Release Notes] for previous changelogs._
 
 <!-- PR links -->
 
+[#380]: https://github.com/munich-quantum-toolkit/workflows/pull/380
 [#377]: https://github.com/munich-quantum-toolkit/workflows/pull/377
 [#363]: https://github.com/munich-quantum-toolkit/workflows/pull/363
 [#356]: https://github.com/munich-quantum-toolkit/workflows/pull/356


### PR DESCRIPTION
## Description

This PR ensures that `reusable-mqt-core-update.yml` runs against `main`. Before, if `reusable-mqt-core-update.yml` was triggered from a PR, commits pushed into the PR were duplicated in the created PR updating MQT Cor.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] ~~I have added appropriate tests that cover the new/changed functionality.~~
- [x] ~~I have updated the documentation to reflect these changes.~~
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] ~~I have added migration instructions to the upgrade guide (if needed).~~
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.
